### PR TITLE
Add login screen and hide sidebar on authentication route

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,32 +1,36 @@
-<div class="flex h-screen bg-gray-100 font-sans">
-  <aside
-    class="w-64 bg-gray-800 text-white flex-shrink-0 flex flex-col fixed inset-y-0 left-0 z-30 transition-transform duration-300 md:translate-x-0"
-    [class.translate-x-0]="isMobileMenuOpen()"
-    [class.-translate-x-full]="!isMobileMenuOpen()"
-  >
-    <app-sidebar (navItemClicked)="isMobileMenuOpen.set(false)" />
-  </aside>
+@if (isLoginRoute()) {
+  <router-outlet></router-outlet>
+} @else {
+  <div class="flex h-screen bg-gray-100 font-sans">
+    <aside
+      class="w-64 bg-gray-800 text-white flex-shrink-0 flex flex-col fixed inset-y-0 left-0 z-30 transition-transform duration-300 md:translate-x-0"
+      [class.translate-x-0]="isMobileMenuOpen()"
+      [class.-translate-x-full]="!isMobileMenuOpen()"
+    >
+      <app-sidebar (navItemClicked)="isMobileMenuOpen.set(false)" />
+    </aside>
 
-  @if (isMobileMenuOpen()) {
-    <div class="fixed inset-0 bg-black/60 z-20 md:hidden" (click)="isMobileMenuOpen.set(false)"></div>
-  }
+    @if (isMobileMenuOpen()) {
+      <div class="fixed inset-0 bg-black/60 z-20 md:hidden" (click)="isMobileMenuOpen.set(false)"></div>
+    }
 
-  <div class="flex-1 flex flex-col overflow-hidden md:pl-64">
-    <header class="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 flex-shrink-0">
-      <button class="md:hidden text-gray-600" (click)="isMobileMenuOpen.set(true)">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
-      </button>
-      
-      <div></div>
+    <div class="flex-1 flex flex-col overflow-hidden md:pl-64">
+      <header class="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 flex-shrink-0">
+        <button class="md:hidden text-gray-600" (click)="isMobileMenuOpen.set(true)">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
 
-      <div class="flex items-center">
-        <span class="mr-3 text-gray-700 font-medium">Admin</span>
-        <div class="w-10 h-10 rounded-full bg-blue-500 text-white flex items-center justify-center font-bold">A</div>
-      </div>
-    </header>
+        <div></div>
 
-    <main class="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 p-4 sm:p-6">
-      <router-outlet></router-outlet>
-    </main>
+        <div class="flex items-center">
+          <span class="mr-3 text-gray-700 font-medium">Admin</span>
+          <div class="w-10 h-10 rounded-full bg-blue-500 text-white flex items-center justify-center font-bold">A</div>
+        </div>
+      </header>
+
+      <main class="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 p-4 sm:p-6">
+        <router-outlet></router-outlet>
+      </main>
+    </div>
   </div>
-</div>
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,14 +4,16 @@ import { EstoqueComponent } from './pages/estoque.component';
 import { OrdensServicoComponent } from './pages/ordens-servico.component';
 import { ResumoOsComponent } from './pages/resumo-os.component';
 import { VeiculosComponent } from './pages/veiculos.component';
+import { LoginComponent } from './pages/login.component';
 
 export const routes: Routes = [
+    { path: 'login', component: LoginComponent },
     { path: 'inicio', component: DashboardComponent },
     { path: 'ordens-servico', component: OrdensServicoComponent },
     { path: 'ordens-servico/:id', component: ResumoOsComponent },
     { path: 'veiculos', component: VeiculosComponent },
     { path: 'estoque', component: EstoqueComponent },
-    
-    { path: '', redirectTo: '/inicio', pathMatch: 'full' }, // Redireciona a raiz para o dashboard
-    { path: '**', redirectTo: '/inicio' } // Rota curinga para qualquer URL inválida
+
+    { path: '', redirectTo: '/login', pathMatch: 'full' }, // Redireciona a raiz para a tela de login
+    { path: '**', redirectTo: '/login' } // Rota curinga para qualquer URL inválida
 ];

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,7 +1,9 @@
-import { Component, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterOutlet } from '@angular/router';
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './layout/sidebar.component';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter, map, startWith } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -11,5 +13,18 @@ import { SidebarComponent } from './layout/sidebar.component';
   styleUrl: './app.scss'
 })
 export class App {
+  private router = inject(Router);
+
   isMobileMenuOpen = signal(false);
+
+  private currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      map(event => event.urlAfterRedirects),
+      startWith(this.router.url)
+    ),
+    { initialValue: this.router.url }
+  );
+
+  isLoginRoute = computed(() => this.currentUrl().startsWith('/login'));
 }

--- a/src/app/pages/login.component.ts
+++ b/src/app/pages/login.component.ts
@@ -1,0 +1,75 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <div class="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8">
+        <div class="text-center mb-8">
+          <h1 class="text-2xl font-semibold text-gray-800">Bem-vindo de volta</h1>
+          <p class="text-sm text-gray-500 mt-2">Acesse sua conta para continuar gerenciando sua oficina.</p>
+        </div>
+
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-6">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2" for="email">E-mail</label>
+            <input
+              id="email"
+              type="email"
+              formControlName="email"
+              class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="seu@email.com"
+            />
+            @if (form.controls.email.touched && form.controls.email.invalid) {
+              <p class="mt-2 text-sm text-red-600">Informe um e-mail válido.</p>
+            }
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2" for="password">Senha</label>
+            <input
+              id="password"
+              type="password"
+              formControlName="password"
+              class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="Digite sua senha"
+            />
+            @if (form.controls.password.touched && form.controls.password.invalid) {
+              <p class="mt-2 text-sm text-red-600">A senha deve ter pelo menos 6 caracteres.</p>
+            }
+          </div>
+
+          <button
+            type="submit"
+            class="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors disabled:opacity-60"
+            [disabled]="form.invalid"
+          >
+            Entrar
+          </button>
+        </form>
+      </div>
+    </div>
+  `,
+})
+export class LoginComponent {
+  private fb = new FormBuilder();
+
+  form = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6)]],
+  });
+
+  onSubmit() {
+    this.form.markAllAsTouched();
+    if (this.form.invalid) {
+      return;
+    }
+
+    // Futuramente, integrar com serviço de autenticação.
+    console.log('Login realizado', this.form.value);
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone login page with a styled reactive form
- register the /login route as the default entry point
- update the root layout to hide the sidebar and header when the login route is active

## Testing
- not run (npm install repeatedly hung in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e58d3c9a348321a69aaf4f95e7f3a7