### PR TITLE
Restyle sidebar wordmark into bespoke SVG logo

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,32 +1,63 @@
-<div class="flex h-screen bg-gray-100 font-sans">
-  <aside
-    class="w-64 bg-gray-800 text-white flex-shrink-0 flex flex-col fixed inset-y-0 left-0 z-30 transition-transform duration-300 md:translate-x-0"
-    [class.translate-x-0]="isMobileMenuOpen()"
-    [class.-translate-x-full]="!isMobileMenuOpen()"
-  >
-    <app-sidebar (navItemClicked)="isMobileMenuOpen.set(false)" />
-  </aside>
+@if (isLoginRoute()) {
+  <router-outlet></router-outlet>
+} @else {
+  <div class="flex h-screen bg-gray-100 font-sans">
+    <aside
+      class="w-64 bg-gray-800 text-white flex-shrink-0 flex flex-col fixed inset-y-0 left-0 z-30 transition-transform duration-300 md:translate-x-0"
+      [class.translate-x-0]="isMobileMenuOpen()"
+      [class.-translate-x-full]="!isMobileMenuOpen()"
+    >
+      <app-sidebar (navItemClicked)="isMobileMenuOpen.set(false)" />
+    </aside>
 
-  @if (isMobileMenuOpen()) {
-    <div class="fixed inset-0 bg-black/60 z-20 md:hidden" (click)="isMobileMenuOpen.set(false)"></div>
-  }
+    @if (isMobileMenuOpen()) {
+      <div class="fixed inset-0 bg-black/60 z-20 md:hidden" (click)="isMobileMenuOpen.set(false)"></div>
+    }
 
-  <div class="flex-1 flex flex-col overflow-hidden md:pl-64">
-    <header class="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 flex-shrink-0">
-      <button class="md:hidden text-gray-600" (click)="isMobileMenuOpen.set(true)">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
-      </button>
-      
-      <div></div>
+    <div class="flex-1 flex flex-col overflow-hidden md:pl-64">
+      <header class="h-16 bg-white/80 backdrop-blur border-b border-gray-200 flex items-center justify-between px-4 sm:px-6 flex-shrink-0">
+        <div class="flex items-center gap-3">
+          <button class="md:hidden text-gray-600" (click)="isMobileMenuOpen.set(true)">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+          </button>
 
-      <div class="flex items-center">
-        <span class="mr-3 text-gray-700 font-medium">Admin</span>
-        <div class="w-10 h-10 rounded-full bg-blue-500 text-white flex items-center justify-center font-bold">A</div>
-      </div>
-    </header>
+          <div class="hidden md:flex items-center gap-2 rounded-full border border-gray-200 px-4 py-1.5 text-sm text-gray-600">
+            <span class="flex h-2 w-2 rounded-full bg-emerald-400"></span>
+            <span>Operação em andamento</span>
+          </div>
+        </div>
 
-    <main class="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 p-4 sm:p-6">
-      <router-outlet></router-outlet>
-    </main>
+        <div class="relative">
+          <button
+            class="flex items-center rounded-full bg-gray-100 pl-2 pr-3 text-left text-sm text-gray-700 transition hover:bg-gray-200"
+            (click)="toggleProfileMenu()"
+          >
+            <div class="mr-2 h-9 w-9 rounded-full bg-gradient-to-br from-blue-500 to-indigo-500 text-white flex items-center justify-center font-semibold">
+              A
+            </div>
+            <div class="hidden sm:block leading-tight">
+              <p class="font-semibold">Ana Rodrigues</p>
+              <p class="text-xs text-gray-500">Administrador</p>
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 h-4 w-4 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9 6 6 6-6" /></svg>
+          </button>
+
+          @if (isProfileMenuOpen()) {
+            <div class="absolute right-0 mt-2 w-48 rounded-2xl border border-gray-100 bg-white p-2 text-sm shadow-xl shadow-gray-900/10">
+              <button class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50" (click)="logout()">
+                <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-red-100 text-red-500">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 17 5-5-5-5M20 12H9m6 7v-1a4 4 0 0 0-4-4H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h6" /></svg>
+                </span>
+                <span class="font-medium">Sair</span>
+              </button>
+            </div>
+          }
+        </div>
+      </header>
+
+      <main class="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 p-4 sm:p-6">
+        <router-outlet></router-outlet>
+      </main>
+    </div>
   </div>
-</div>
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,14 +4,18 @@ import { EstoqueComponent } from './pages/estoque.component';
 import { OrdensServicoComponent } from './pages/ordens-servico.component';
 import { ResumoOsComponent } from './pages/resumo-os.component';
 import { VeiculosComponent } from './pages/veiculos.component';
+import { LoginComponent } from './pages/login.component';
+import { ClientesComponent } from './pages/clientes.component';
 
 export const routes: Routes = [
+    { path: 'login', component: LoginComponent },
     { path: 'inicio', component: DashboardComponent },
     { path: 'ordens-servico', component: OrdensServicoComponent },
     { path: 'ordens-servico/:id', component: ResumoOsComponent },
     { path: 'veiculos', component: VeiculosComponent },
     { path: 'estoque', component: EstoqueComponent },
-    
-    { path: '', redirectTo: '/inicio', pathMatch: 'full' }, // Redireciona a raiz para o dashboard
-    { path: '**', redirectTo: '/inicio' } // Rota curinga para qualquer URL inválida
+    { path: 'clientes', component: ClientesComponent },
+
+    { path: '', redirectTo: '/login', pathMatch: 'full' }, // Redireciona a raiz para a tela de login
+    { path: '**', redirectTo: '/login' } // Rota curinga para qualquer URL inválida
 ];

--- a/src/app/core/models/models.ts
+++ b/src/app/core/models/models.ts
@@ -17,6 +17,8 @@ export interface Servico {
 export interface Cliente {
   id: number;
   nome: string;
+  email?: string;
+  telefone?: string;
 }
 
 export interface Veiculo {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -10,10 +10,10 @@ export class DataService {
   // Usando Signals para reatividade.
   
   readonly clientes = signal<Cliente[]>([
-    { id: 1, nome: 'Carlos Alberto' },
-    { id: 2, nome: 'Joana Pereira' },
-    { id: 3, nome: 'Pedro Henrique' },
-    { id: 4, nome: 'João da Silva' },
+    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
+    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
+    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
+    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' },
   ]);
 
   readonly veiculos = signal<Veiculo[]>([
@@ -37,10 +37,42 @@ export class DataService {
   ]);
 
   readonly ordensServico = signal<OrdemServico[]>([
-    { id: 974, veiculoId: 1, clienteId: 1, dataEntrada: '2025-09-07', status: 'Em Andamento', servicos: [{id: 201, qtde: 1}], pecas: [{id: 101, qtde: 1}, {id: 104, qtde: 1}] },
-    { id: 973, veiculoId: 1, clienteId: 1, dataEntrada: '2025-09-06', status: 'Finalizada', servicos: [{id: 202, qtde: 1}], pecas: [] },
-    { id: 971, veiculoId: 2, clienteId: 3, dataEntrada: '2025-09-05', status: 'Aguardando Aprovação', servicos: [{id: 203, qtde: 1}], pecas: [{id: 102, qtde: 2}] },
-    { id: 968, veiculoId: 3, clienteId: 4, dataEntrada: '2025-09-02', status: 'Finalizada', servicos: [{id: 201, qtde: 1}], pecas: [{id: 101, qtde: 1}, {id: 104, qtde: 1}] },
+    {
+      id: 974,
+      veiculoId: 1,
+      clienteId: 1,
+      dataEntrada: '2025-09-07',
+      status: 'Em Andamento',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+    },
+    {
+      id: 973,
+      veiculoId: 1,
+      clienteId: 1,
+      dataEntrada: '2025-09-06',
+      status: 'Finalizada',
+      servicos: [{ id: 202, qtde: 1 }],
+      pecas: [],
+    },
+    {
+      id: 971,
+      veiculoId: 2,
+      clienteId: 3,
+      dataEntrada: '2025-09-05',
+      status: 'Aguardando Aprovação',
+      servicos: [{ id: 203, qtde: 1 }],
+      pecas: [{ id: 102, qtde: 2 }],
+    },
+    {
+      id: 968,
+      veiculoId: 3,
+      clienteId: 4,
+      dataEntrada: '2025-09-02',
+      status: 'Finalizada',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+    },
   ]);
 
   constructor() { }

--- a/src/app/layout/sidebar.component.ts
+++ b/src/app/layout/sidebar.component.ts
@@ -8,33 +8,98 @@ import { MenuItem } from '../core/models/models';
   standalone: true,
   imports: [CommonModule, RouterLink, RouterLinkActive],
   template: `
-    <div class="h-16 flex items-center justify-center px-4 bg-gray-900">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-blue-400 h-8 w-8 mr-2"><path d="M13.5 21v-7.5a.75.75 0 0 1 .75-.75h3a.75.75 0 0 1 .75.75V21m-4.5 0H2.36m11.14 0H18m0 0h3.64m-1.39 0V9.349M3.75 21V9.349m0 0a3.001 3.001 0 0 0 3.75-.615A2.993 2.993 0 0 0 9.75 9.75c.896 0 1.7-.393 2.25-1.016a2.993 2.993 0 0 0 2.25 1.016c.896 0 1.7-.393 2.25-1.015a3.001 3.001 0 0 0 3.75.614m-16.5 0a3.004 3.004 0 0 1-.621-4.72l1.189-1.19A1.5 1.5 0 0 1 5.378 3h13.243a1.5 1.5 0 0 1 1.06.44l1.19 1.189a3 3 0 0 1-.621 4.72M6.75 18h3.75a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75H6.75a.75.75 0 0 0-.75.75v3.75c0 .414.336.75.75.75Z"/></svg>
-      <span class="text-xl font-semibold">PlanuCenter</span>
-    </div>
-    <nav class="flex-1 px-2 py-4 space-y-2">
-      @for (item of menuItems; track item.id) {
-        <a
-          [routerLink]="item.path"
-          routerLinkActive="bg-blue-500 text-white"
-          [routerLinkActiveOptions]="{exact: true}"
-          (click)="navItemClicked.emit()"
-          class="flex items-center px-4 py-2.5 text-sm font-medium rounded-md transition-colors text-gray-300 hover:bg-gray-700 hover:text-white"
+    <div class="flex h-full flex-col bg-gradient-to-b from-gray-950 via-gray-900 to-gray-800 text-gray-100">
+      <div class="flex h-24 items-center justify-center px-6">
+        <svg
+          role="img"
+          aria-labelledby="planu-logo-title"
+          viewBox="0 0 420 96"
+          class="h-16 w-full text-white"
+          preserveAspectRatio="xMidYMid meet"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5 mr-3"><path [attr.d]="item.iconPath"/></svg>
-          {{ item.label }}
-        </a>
-      }
-    </nav>
+          <title id="planu-logo-title">PlanuCenter</title>
+          <defs>
+            <linearGradient id="pc-wordmark" x1="12" x2="408" y1="18" y2="82" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#2CD4FF" />
+              <stop offset="45%" stop-color="#3B82F6" />
+              <stop offset="100%" stop-color="#7C3AED" />
+            </linearGradient>
+            <linearGradient id="pc-underline" x1="30" x2="390" y1="86" y2="86" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#38BDF8" stop-opacity="0" />
+              <stop offset="40%" stop-color="#38BDF8" stop-opacity=".45" />
+              <stop offset="60%" stop-color="#8B5CF6" stop-opacity=".45" />
+              <stop offset="100%" stop-color="#8B5CF6" stop-opacity="0" />
+            </linearGradient>
+            <radialGradient id="pc-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(210 44) scale(210 36)">
+              <stop offset="0%" stop-color="#60A5FA" stop-opacity=".35" />
+              <stop offset="100%" stop-color="#1E3A8A" stop-opacity="0" />
+            </radialGradient>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path d="M48 24c22-16 62-20 94-8 34 12 75 12 118-2 36-12 77-8 112 12" stroke="url(#pc-wordmark)" stroke-width="6" stroke-linecap="round" opacity=".35" />
+            <ellipse cx="210" cy="54" rx="190" ry="36" fill="url(#pc-glow)" />
+            <text
+              x="50%"
+              y="60"
+              text-anchor="middle"
+              font-family="'Poppins','Inter','Segoe UI',sans-serif"
+              font-size="44"
+              font-weight="700"
+              letter-spacing="0.06em"
+              fill="url(#pc-wordmark)"
+            >
+              Planu
+              <tspan fill="#F8FAFC" font-weight="800">Center</tspan>
+            </text>
+            <path d="M60 78h300" stroke="url(#pc-underline)" stroke-width="6" stroke-linecap="round" />
+          </g>
+        </svg>
+      </div>
+
+      <div class="flex-1 overflow-y-auto px-3 pb-6">
+        <div class="rounded-2xl bg-white/5 p-3">
+          <p class="px-3 text-xs font-semibold uppercase tracking-wider text-gray-400">Navegação</p>
+          <nav class="mt-2 space-y-1">
+            @for (item of menuItems; track item.id) {
+              <a
+                [routerLink]="item.path"
+                routerLinkActive="bg-blue-500/80 text-white shadow-lg shadow-blue-900/30"
+                [routerLinkActiveOptions]="{ exact: true }"
+                (click)="navItemClicked.emit()"
+                class="flex items-center rounded-xl px-4 py-2 text-sm font-medium text-gray-300 transition-all duration-200 hover:bg-white/10 hover:text-white"
+              >
+                <span class="mr-3 flex h-9 w-9 items-center justify-center rounded-lg bg-white/5">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="h-5 w-5"
+                  >
+                    <path [attr.d]="item.iconPath" />
+                  </svg>
+                </span>
+                <span>{{ item.label }}</span>
+              </a>
+            }
+          </nav>
+        </div>
+      </div>
+
+    </div>
   `,
 })
 export class SidebarComponent {
   @Output() navItemClicked = new EventEmitter<void>();
 
   menuItems: MenuItem[] = [
-    { id: 'inicio', label: 'Início', path: '/', iconPath: 'M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z' },
+    { id: 'inicio', label: 'Início', path: '/inicio', iconPath: 'M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z' },
     { id: 'ordem_servico', label: 'Ordens de Serviço', path: '/ordens-servico', iconPath: 'M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z M16 18H8 M16 14H8 M12 10H8' },
     { id: 'veiculos', label: 'Veículos', path: '/veiculos', iconPath: 'M18.92 6.01C18.72 5.42 18.16 5 17.5 5h-11C5.84 5 5.28 5.42 5.08 6.01L3 12v8c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h12v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-8l-2.08-5.99zM6.5 16c-.83 0-1.5-.67-1.5-1.5S5.67 13 6.5 13s1.5.67 1.5 1.5S7.33 16 6.5 16zm11 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zM5 11l1.5-4.5h11L19 11H5z' },
     { id: 'estoque', label: 'Estoque', path: '/estoque', iconPath: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z' },
+    { id: 'clientes', label: 'Clientes', path: '/clientes', iconPath: 'M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2 M8 7a4 4 0 1 0 0-8 4 4 0 0 0 0 8 M20 21v-2a4 4 0 0 0-3-3.87 M17 3a4 4 0 0 1 0 8' },
   ];
 }

--- a/src/app/pages/clientes.component.ts
+++ b/src/app/pages/clientes.component.ts
@@ -1,0 +1,236 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DataService } from '../core/services/data.service';
+import { Cliente } from '../core/models/models';
+
+@Component({
+  selector: 'app-clientes',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="bg-white p-6 rounded-lg shadow-md">
+      <div class="flex flex-col md:flex-row justify-between items-center mb-4">
+        <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Gestão de Clientes</h2>
+        @if (modoVisualizacao() === 'lista') {
+          <button
+            class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors"
+            (click)="abrirFormularioNovo()"
+          >
+            + Cadastrar Cliente
+          </button>
+        } @else {
+          <button
+            class="w-full md:w-auto bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-md hover:bg-gray-300 transition-colors"
+            (click)="voltarParaLista()"
+          >
+            Voltar para a lista
+          </button>
+        }
+      </div>
+
+      @if (modoVisualizacao() === 'lista') {
+        <div class="overflow-x-auto">
+          <table class="min-w-full bg-white">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">E-mail</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
+                <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+              </tr>
+            </thead>
+            <tbody class="text-gray-600 text-sm font-light">
+              @for (cliente of clientes(); track cliente.id) {
+                <tr class="border-b border-gray-200 hover:bg-gray-50">
+                  <td class="py-3 px-6 text-left">{{ cliente.nome }}</td>
+                  <td class="py-3 px-6 text-left">{{ cliente.email }}</td>
+                  <td class="py-3 px-6 text-left">{{ cliente.telefone }}</td>
+                  <td class="py-3 px-6 text-center">
+                    <div class="flex justify-center gap-2">
+                      <button
+                        class="bg-blue-500 text-white py-1 px-3 rounded-md hover:bg-blue-600 text-xs"
+                        (click)="verDetalhes(cliente)"
+                      >
+                        Ver Detalhes
+                      </button>
+                      <button
+                        class="bg-gray-200 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-300 text-xs"
+                        (click)="editarCliente(cliente)"
+                      >
+                        Editar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+
+      @if (modoVisualizacao() === 'formulario') {
+        <form class="grid gap-4 md:grid-cols-2" (ngSubmit)="salvarCliente()">
+          <label class="flex flex-col text-sm text-gray-600 md:col-span-2">
+            Nome completo
+            <input class="mt-1 rounded-md border-gray-300" name="nome" [(ngModel)]="formulario.nome" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            E-mail
+            <input class="mt-1 rounded-md border-gray-300" type="email" name="email" [(ngModel)]="formulario.email" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Telefone
+            <input class="mt-1 rounded-md border-gray-300" name="telefone" [(ngModel)]="formulario.telefone" required />
+          </label>
+
+          <div class="md:col-span-2 flex justify-end gap-3">
+            <button type="button" class="px-4 py-2 rounded-md border border-gray-300" (click)="voltarParaLista()">Cancelar</button>
+            <button type="submit" class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">
+              {{ editandoId() ? 'Atualizar Cliente' : 'Salvar Cliente' }}
+            </button>
+          </div>
+        </form>
+      }
+
+      @if (modoVisualizacao() === 'detalhes' && clienteSelecionado()) {
+        <div class="space-y-4">
+          <div class="flex justify-between items-center">
+            <h3 class="text-base font-semibold text-gray-700">Resumo do Cliente</h3>
+            <button class="text-sm text-blue-600 hover:underline" (click)="voltarParaLista()">Voltar para a lista</button>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-2 text-sm text-gray-600">
+            <div>
+              <span class="font-semibold text-gray-700 block">Nome</span>
+              {{ clienteSelecionado()!.nome }}
+            </div>
+            <div>
+              <span class="font-semibold text-gray-700 block">E-mail</span>
+              {{ clienteSelecionado()!.email }}
+            </div>
+            <div>
+              <span class="font-semibold text-gray-700 block">Telefone</span>
+              {{ clienteSelecionado()!.telefone }}
+            </div>
+            <div>
+              <span class="font-semibold text-gray-700 block">Veículos cadastrados</span>
+              {{ veiculosDoCliente().length }}
+            </div>
+          </div>
+
+          <div>
+            <h4 class="font-semibold text-gray-700 mb-2">Veículos do cliente</h4>
+            <ul class="space-y-2 text-sm text-gray-600">
+              @if (veiculosDoCliente().length) {
+                @for (veiculo of veiculosDoCliente(); track veiculo.id) {
+                  <li class="flex flex-col md:flex-row md:items-center md:justify-between bg-gray-50 rounded-md px-3 py-2">
+                    <span>{{ veiculo.marca }} {{ veiculo.modelo }} ({{ veiculo.placa }})</span>
+                    <span class="text-gray-500 text-xs">Ano {{ veiculo.ano }}</span>
+                  </li>
+                }
+              } @else {
+                <li class="text-gray-500">Nenhum veículo cadastrado para este cliente.</li>
+              }
+            </ul>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+})
+export class ClientesComponent {
+  private dataService = inject(DataService);
+
+  clientes = this.dataService.clientes;
+  veiculos = this.dataService.veiculos;
+
+  modoVisualizacao = signal<'lista' | 'formulario' | 'detalhes'>('lista');
+  editandoId = signal<number | null>(null);
+  clienteSelecionadoId = signal<number | null>(null);
+
+  formulario = {
+    nome: '',
+    email: '',
+    telefone: '',
+  };
+
+  clienteSelecionado = computed(() => {
+    const id = this.clienteSelecionadoId();
+    if (id == null) {
+      return undefined;
+    }
+    return this.clientes().find(cliente => cliente.id === id);
+  });
+
+  veiculosDoCliente = computed(() => {
+    if (!this.clienteSelecionado()) {
+      return [];
+    }
+    return this.veiculos().filter(veiculo => veiculo.clienteId === this.clienteSelecionado()!.id);
+  });
+
+  abrirFormularioNovo() {
+    this.editandoId.set(null);
+    this.formulario = {
+      nome: '',
+      email: '',
+      telefone: '',
+    };
+    this.modoVisualizacao.set('formulario');
+  }
+
+  editarCliente(cliente: Cliente) {
+    this.editandoId.set(cliente.id);
+    this.formulario = {
+      nome: cliente.nome,
+      email: cliente.email || '',
+      telefone: cliente.telefone || '',
+    };
+    this.modoVisualizacao.set('formulario');
+  }
+
+  verDetalhes(cliente: Cliente) {
+    this.clienteSelecionadoId.set(cliente.id);
+    this.modoVisualizacao.set('detalhes');
+  }
+
+  salvarCliente() {
+    if (!this.formulario.nome || !this.formulario.email || !this.formulario.telefone) {
+      return;
+    }
+
+    const dadosNormalizados = {
+      nome: this.formulario.nome.trim(),
+      email: this.formulario.email.trim(),
+      telefone: this.formulario.telefone.trim(),
+    };
+
+    if (this.editandoId()) {
+      const idParaAtualizar = this.editandoId()!;
+      this.dataService.clientes.update(lista =>
+        lista.map(item =>
+          item.id === idParaAtualizar
+            ? { ...item, ...dadosNormalizados }
+            : item,
+        ),
+      );
+    } else {
+      const novoId = this.dataService.clientes().reduce((max, cliente) => Math.max(max, cliente.id), 0) + 1;
+      this.dataService.clientes.update(lista => [
+        { id: novoId, ...dadosNormalizados },
+        ...lista,
+      ]);
+    }
+
+    this.voltarParaLista();
+  }
+
+  voltarParaLista() {
+    this.modoVisualizacao.set('lista');
+    this.editandoId.set(null);
+    this.clienteSelecionadoId.set(null);
+  }
+}

--- a/src/app/pages/estoque.component.ts
+++ b/src/app/pages/estoque.component.ts
@@ -1,49 +1,194 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { DataService } from '../core/services/data.service';
+import { Peca } from '../core/models/models';
 
 @Component({
   selector: 'app-estoque',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   template: `
     <div class="bg-white p-6 rounded-lg shadow-md">
       <div class="flex flex-col md:flex-row justify-between items-center mb-4">
-          <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Controle de Estoque de Peças</h2>
-          <button class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors">
-              + Adicionar Peça
+        <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Controle de Estoque de Peças</h2>
+        @if (modoVisualizacao() === 'lista') {
+          <button
+            class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors"
+            (click)="abrirFormularioNovo()"
+          >
+            + Adicionar Peça
           </button>
+        } @else {
+          <button
+            class="w-full md:w-auto bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-md hover:bg-gray-300 transition-colors"
+            (click)="voltarParaLista()"
+          >
+            Voltar para a lista
+          </button>
+        }
       </div>
-      <div class="overflow-x-auto">
+
+      @if (modoVisualizacao() === 'lista') {
+        <div class="overflow-x-auto">
           <table class="min-w-full bg-white">
-              <thead class="bg-gray-50">
-                  <tr>
-                      <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Código</th>
-                      <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome da Peça</th>
-                      <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Qtd. Estoque</th>
-                      <th class="py-3 px-6 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Preço (R$)</th>
-                      <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
-                  </tr>
-              </thead>
-              <tbody class="text-gray-600 text-sm font-light">
-                @for(p of pecas(); track p.id) {
-                  <tr class="border-b border-gray-200 hover:bg-gray-50">
-                      <td class="py-3 px-6 text-left">{{p.codigo}}</td>
-                      <td class="py-3 px-6 text-left">{{p.nome}}</td>
-                      <td class="py-3 px-6 text-center">{{p.estoque}}</td>
-                      <td class="py-3 px-6 text-right">{{p.preco | currency:'BRL'}}</td>
-                       <td class="py-3 px-6 text-center">
-                          <button class="bg-gray-200 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-300 text-xs">Editar</button>
-                      </td>
-                  </tr>
-                }
-              </tbody>
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Código</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome da Peça</th>
+                <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Qtd. Estoque</th>
+                <th class="py-3 px-6 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Preço (R$)</th>
+                <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+              </tr>
+            </thead>
+            <tbody class="text-gray-600 text-sm font-light">
+              @for (peca of pecas(); track peca.id) {
+                <tr class="border-b border-gray-200 hover:bg-gray-50">
+                  <td class="py-3 px-6 text-left">{{ peca.codigo }}</td>
+                  <td class="py-3 px-6 text-left">{{ peca.nome }}</td>
+                  <td class="py-3 px-6 text-center">{{ peca.estoque }}</td>
+                  <td class="py-3 px-6 text-right">{{ peca.preco | currency:'BRL' }}</td>
+                  <td class="py-3 px-6 text-center">
+                    <div class="flex justify-center gap-2">
+                      <button
+                        class="bg-gray-200 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-300 text-xs"
+                        (click)="editarPeca(peca)"
+                      >
+                        Editar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
           </table>
-      </div>
+        </div>
+      }
+
+      @if (modoVisualizacao() === 'formulario') {
+        <form class="grid gap-4 md:grid-cols-2" (ngSubmit)="salvarPeca()">
+          <label class="flex flex-col text-sm text-gray-600">
+            Código
+            <input class="mt-1 rounded-md border-gray-300" name="codigo" [(ngModel)]="formulario.codigo" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Nome
+            <input class="mt-1 rounded-md border-gray-300" name="nome" [(ngModel)]="formulario.nome" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Quantidade em estoque
+            <input
+              type="number"
+              min="0"
+              class="mt-1 rounded-md border-gray-300"
+              name="estoque"
+              [(ngModel)]="formulario.estoque"
+              required
+            />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Preço
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              class="mt-1 rounded-md border-gray-300"
+              name="preco"
+              [(ngModel)]="formulario.preco"
+              required
+            />
+          </label>
+
+          <div class="md:col-span-2 flex justify-end gap-3">
+            <button type="button" class="px-4 py-2 rounded-md border border-gray-300" (click)="voltarParaLista()">Cancelar</button>
+            <button type="submit" class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">
+              {{ editandoId() ? 'Atualizar Peça' : 'Salvar Peça' }}
+            </button>
+          </div>
+        </form>
+      }
     </div>
   `,
 })
 export class EstoqueComponent {
   private dataService = inject(DataService);
+
   pecas = this.dataService.pecas;
+
+  modoVisualizacao = signal<'lista' | 'formulario'>('lista');
+  editandoId = signal<number | null>(null);
+
+  formulario = {
+    codigo: '',
+    nome: '',
+    estoque: 0,
+    preco: 0,
+  };
+
+  abrirFormularioNovo() {
+    this.editandoId.set(null);
+    this.formulario = {
+      codigo: '',
+      nome: '',
+      estoque: 0,
+      preco: 0,
+    };
+    this.modoVisualizacao.set('formulario');
+  }
+
+  editarPeca(peca: Peca) {
+    this.editandoId.set(peca.id);
+    this.formulario = {
+      codigo: peca.codigo,
+      nome: peca.nome,
+      estoque: peca.estoque,
+      preco: peca.preco,
+    };
+    this.modoVisualizacao.set('formulario');
+  }
+
+  salvarPeca() {
+    if (!this.formulario.codigo || !this.formulario.nome) {
+      return;
+    }
+
+    if (this.editandoId()) {
+      const idParaAtualizar = this.editandoId()!;
+      this.dataService.pecas.update(lista =>
+        lista.map(item =>
+          item.id === idParaAtualizar
+            ? {
+                ...item,
+                codigo: this.formulario.codigo,
+                nome: this.formulario.nome,
+                estoque: Number(this.formulario.estoque),
+                preco: Number(this.formulario.preco),
+              }
+            : item,
+        ),
+      );
+    } else {
+      const novoId = this.dataService.pecas().reduce((max, peca) => Math.max(max, peca.id), 0) + 1;
+      this.dataService.pecas.update(lista => [
+        {
+          id: novoId,
+          codigo: this.formulario.codigo,
+          nome: this.formulario.nome,
+          estoque: Number(this.formulario.estoque),
+          preco: Number(this.formulario.preco),
+        },
+        ...lista,
+      ]);
+    }
+
+    this.voltarParaLista();
+  }
+
+  voltarParaLista() {
+    this.modoVisualizacao.set('lista');
+    this.editandoId.set(null);
+  }
 }

--- a/src/app/pages/login.component.ts
+++ b/src/app/pages/login.component.ts
@@ -1,0 +1,75 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <div class="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8">
+        <div class="text-center mb-8">
+          <h1 class="text-2xl font-semibold text-gray-800">Bem-vindo de volta</h1>
+          <p class="text-sm text-gray-500 mt-2">Acesse sua conta para continuar gerenciando sua oficina.</p>
+        </div>
+
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-6">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2" for="email">E-mail</label>
+            <input
+              id="email"
+              type="email"
+              formControlName="email"
+              class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="seu@email.com"
+            />
+            @if (form.controls.email.touched && form.controls.email.invalid) {
+              <p class="mt-2 text-sm text-red-600">Informe um e-mail válido.</p>
+            }
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2" for="password">Senha</label>
+            <input
+              id="password"
+              type="password"
+              formControlName="password"
+              class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="Digite sua senha"
+            />
+            @if (form.controls.password.touched && form.controls.password.invalid) {
+              <p class="mt-2 text-sm text-red-600">A senha deve ter pelo menos 6 caracteres.</p>
+            }
+          </div>
+
+          <button
+            type="submit"
+            class="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors disabled:opacity-60"
+            [disabled]="form.invalid"
+          >
+            Entrar
+          </button>
+        </form>
+      </div>
+    </div>
+  `,
+})
+export class LoginComponent {
+  private fb = new FormBuilder();
+
+  form = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6)]],
+  });
+
+  onSubmit() {
+    this.form.markAllAsTouched();
+    if (this.form.invalid) {
+      return;
+    }
+
+    // Futuramente, integrar com serviço de autenticação.
+    console.log('Login realizado', this.form.value);
+  }
+}

--- a/src/app/pages/ordens-servico.component.ts
+++ b/src/app/pages/ordens-servico.component.ts
@@ -1,55 +1,263 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { DataService } from '../core/services/data.service';
-import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-ordens-servico',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, FormsModule],
   template: `
     <div class="bg-white p-6 rounded-lg shadow-md">
       <div class="flex flex-col md:flex-row justify-between items-center mb-4">
-          <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Gerenciar Ordens de Serviço</h2>
-          <button class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors">
-              + Nova Ordem de Serviço
-          </button>
+        <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Gerenciar Ordens de Serviço</h2>
+        <button
+          class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors"
+          (click)="abrirFormulario()"
+        >
+          + Nova Ordem de Serviço
+        </button>
       </div>
-      <div class="overflow-x-auto">
+
+      @if (modoVisualizacao() === 'lista') {
+        <div class="overflow-x-auto">
           <table class="min-w-full bg-white">
-              <thead class="bg-gray-50">
-                  <tr>
-                      <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">OS</th>
-                      <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Placa</th>
-                      <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
-                      <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Veículo</th>
-                      <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
-                  </tr>
-              </thead>
-              <tbody class="text-gray-600 text-sm font-light">
-                @for (os of ordensServico(); track os.id) {
-                  <tr class="border-b border-gray-200 hover:bg-gray-50">
-                      <td class="py-3 px-6 text-left whitespace-nowrap"><a [routerLink]="['/ordens-servico', os.id]" class="text-blue-600 font-medium hover:underline">#{{os.id}}</a></td>
-                      <td class="py-3 px-6 text-left">{{ getVeiculo(os.veiculoId)?.placa }}</td>
-                      <td class="py-3 px-6 text-left">{{ getCliente(os.clienteId)?.nome }}</td>
-                      <td class="py-3 px-6 text-left">{{ getVeiculo(os.veiculoId)?.marca }} {{ getVeiculo(os.veiculoId)?.modelo }}</td>
-                      <td class="py-3 px-6 text-center">
-                          <a [routerLink]="['/ordens-servico', os.id]" class="bg-blue-500 text-white py-1 px-3 rounded-md hover:bg-blue-600 text-xs">Ver Resumo</a>
-                      </td>
-                  </tr>
-                }
-              </tbody>
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">OS</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Placa</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Veículo</th>
+                <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+              </tr>
+            </thead>
+            <tbody class="text-gray-600 text-sm font-light">
+              @for (os of ordensServico(); track os.id) {
+                <tr class="border-b border-gray-200 hover:bg-gray-50">
+                  <td class="py-3 px-6 text-left whitespace-nowrap">
+                    <span class="text-blue-600 font-medium">#{{ os.id }}</span>
+                  </td>
+                  <td class="py-3 px-6 text-left">{{ getVeiculo(os.veiculoId)?.placa }}</td>
+                  <td class="py-3 px-6 text-left">{{ getCliente(os.clienteId)?.nome }}</td>
+                  <td class="py-3 px-6 text-left">
+                    {{ getVeiculo(os.veiculoId)?.marca }} {{ getVeiculo(os.veiculoId)?.modelo }}
+                  </td>
+                  <td class="py-3 px-6 text-center">
+                    <button
+                      class="bg-blue-500 text-white py-1 px-3 rounded-md hover:bg-blue-600 text-xs"
+                      (click)="verResumo(os.id)"
+                    >
+                      Ver Resumo
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
           </table>
-      </div>
+        </div>
+      }
+
+      @if (modoVisualizacao() === 'formulario') {
+        <div class="space-y-4">
+          <div class="flex justify-between items-center">
+            <h3 class="text-base font-semibold text-gray-700">Nova Ordem de Serviço</h3>
+            <button class="text-sm text-blue-600 hover:underline" (click)="voltarParaLista()">Voltar para a lista</button>
+          </div>
+          <form class="grid gap-4 md:grid-cols-2" (ngSubmit)="salvarOrdem()">
+            <label class="flex flex-col text-sm text-gray-600">
+              Cliente
+              <select class="mt-1 rounded-md border-gray-300" [(ngModel)]="formularioOrdem.clienteId" name="clienteId" required>
+                <option [ngValue]="undefined" disabled>Selecione um cliente</option>
+                @for (cliente of clientes(); track cliente.id) {
+                  <option [ngValue]="cliente.id">{{ cliente.nome }}</option>
+                }
+              </select>
+            </label>
+
+            <label class="flex flex-col text-sm text-gray-600">
+              Veículo
+              <select class="mt-1 rounded-md border-gray-300" [(ngModel)]="formularioOrdem.veiculoId" name="veiculoId" required>
+                <option [ngValue]="undefined" disabled>Selecione um veículo</option>
+                @for (veiculo of veiculosDisponiveis(); track veiculo?.id) {
+                  <option [ngValue]="veiculo?.id">{{ veiculo?.placa }} - {{ veiculo?.marca }} {{ veiculo?.modelo }}</option>
+                }
+              </select>
+            </label>
+
+            <label class="flex flex-col text-sm text-gray-600">
+              Data de entrada
+              <input
+                type="date"
+                class="mt-1 rounded-md border-gray-300"
+                [(ngModel)]="formularioOrdem.dataEntrada"
+                name="dataEntrada"
+                required
+              />
+            </label>
+
+            <label class="flex flex-col text-sm text-gray-600">
+              Status
+              <select class="mt-1 rounded-md border-gray-300" [(ngModel)]="formularioOrdem.status" name="status" required>
+                <option [ngValue]="undefined" disabled>Selecione</option>
+                <option value="Em Andamento">Em Andamento</option>
+                <option value="Aguardando Aprovação">Aguardando Aprovação</option>
+                <option value="Finalizada">Finalizada</option>
+                <option value="Cancelada">Cancelada</option>
+              </select>
+            </label>
+
+            <label class="flex flex-col text-sm text-gray-600 md:col-span-2">
+              Observações
+              <textarea
+                rows="4"
+                class="mt-1 rounded-md border-gray-300"
+                [(ngModel)]="formularioOrdem.observacoes"
+                name="observacoes"
+                placeholder="Inclua detalhes adicionais, serviços previstos ou peças necessárias"
+              ></textarea>
+            </label>
+
+            <div class="md:col-span-2 flex justify-end gap-3">
+              <button type="button" class="px-4 py-2 rounded-md border border-gray-300" (click)="voltarParaLista()">Cancelar</button>
+              <button type="submit" class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Salvar Ordem</button>
+            </div>
+          </form>
+        </div>
+      }
+
+      @if (modoVisualizacao() === 'resumo' && ordemSelecionada()) {
+        <div class="space-y-4">
+          <div class="flex justify-between items-center">
+            <h3 class="text-base font-semibold text-gray-700">Resumo da Ordem #{{ ordemSelecionada()?.id }}</h3>
+            <button class="text-sm text-blue-600 hover:underline" (click)="voltarParaLista()">Voltar para a lista</button>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-2 text-sm text-gray-600">
+            <div>
+              <span class="font-semibold text-gray-700 block">Cliente</span>
+              {{ getCliente(ordemSelecionada()!.clienteId)?.nome }}
+            </div>
+            <div>
+              <span class="font-semibold text-gray-700 block">Veículo</span>
+              {{ getVeiculo(ordemSelecionada()!.veiculoId)?.marca }} {{ getVeiculo(ordemSelecionada()!.veiculoId)?.modelo }}
+              ({{ getVeiculo(ordemSelecionada()!.veiculoId)?.placa }})
+            </div>
+            <div>
+              <span class="font-semibold text-gray-700 block">Data de entrada</span>
+              {{ ordemSelecionada()!.dataEntrada | date:'dd/MM/yyyy' }}
+            </div>
+            <div>
+              <span class="font-semibold text-gray-700 block">Status</span>
+              {{ ordemSelecionada()!.status }}
+            </div>
+            <div class="md:col-span-2">
+              <span class="font-semibold text-gray-700 block">Observações</span>
+              {{ ordemSelecionada()!.observacoes || 'Sem observações registradas.' }}
+            </div>
+          </div>
+
+          <div class="grid md:grid-cols-2 gap-4">
+            <div>
+              <h4 class="font-semibold text-gray-700 mb-2">Serviços</h4>
+              <ul class="space-y-2 text-sm text-gray-600">
+                @if (ordemSelecionada()!.servicos.length) {
+                  @for (servico of ordemSelecionada()!.servicos; track servico.id) {
+                    <li class="flex justify-between bg-gray-50 rounded-md px-3 py-2">
+                      <span>{{ getServico(servico.id)?.descricao }}</span>
+                      <span>x{{ servico.qtde }}</span>
+                    </li>
+                  }
+                } @else {
+                  <li class="text-gray-500">Nenhum serviço vinculado.</li>
+                }
+              </ul>
+            </div>
+            <div>
+              <h4 class="font-semibold text-gray-700 mb-2">Peças</h4>
+              <ul class="space-y-2 text-sm text-gray-600">
+                @if (ordemSelecionada()!.pecas.length) {
+                  @for (peca of ordemSelecionada()!.pecas; track peca.id) {
+                    <li class="flex justify-between bg-gray-50 rounded-md px-3 py-2">
+                      <span>{{ getPeca(peca.id)?.nome }}</span>
+                      <span>x{{ peca.qtde }}</span>
+                    </li>
+                  }
+                } @else {
+                  <li class="text-gray-500">Nenhuma peça vinculada.</li>
+                }
+              </ul>
+            </div>
+          </div>
+        </div>
+      }
     </div>
   `,
 })
 export class OrdensServicoComponent {
   private dataService = inject(DataService);
-  
+
   ordensServico = this.dataService.ordensServico;
   veiculos = this.dataService.veiculos;
   clientes = this.dataService.clientes;
+  servicos = this.dataService.servicos;
+  pecas = this.dataService.pecas;
+
+  modoVisualizacao = signal<'lista' | 'formulario' | 'resumo'>('lista');
+  ordemSelecionadaId = signal<number | null>(null);
+
+  formularioOrdem = {
+    clienteId: undefined as number | undefined,
+    veiculoId: undefined as number | undefined,
+    dataEntrada: '',
+    status: undefined as 'Em Andamento' | 'Aguardando Aprovação' | 'Finalizada' | 'Cancelada' | undefined,
+    observacoes: '',
+  };
+
+  ordemSelecionada = computed(() => {
+    const id = this.ordemSelecionadaId();
+    if (id == null) {
+      return undefined;
+    }
+    return this.dataService.getOrdemServicoById(id);
+  });
+
+  abrirFormulario() {
+    this.limparFormulario();
+    this.modoVisualizacao.set('formulario');
+  }
+
+  verResumo(id: number) {
+    this.ordemSelecionadaId.set(id);
+    this.modoVisualizacao.set('resumo');
+  }
+
+  voltarParaLista() {
+    this.modoVisualizacao.set('lista');
+    this.ordemSelecionadaId.set(null);
+  }
+
+  salvarOrdem() {
+    if (!this.formularioOrdem.clienteId || !this.formularioOrdem.veiculoId || !this.formularioOrdem.dataEntrada || !this.formularioOrdem.status) {
+      return;
+    }
+
+    const novaOrdemId = this.ordensServico().reduce((max, os) => Math.max(max, os.id), 0) + 1;
+    this.dataService.ordensServico.update(ordens => [
+      {
+        id: novaOrdemId,
+        clienteId: this.formularioOrdem.clienteId!,
+        veiculoId: this.formularioOrdem.veiculoId!,
+        dataEntrada: this.formularioOrdem.dataEntrada,
+        status: this.formularioOrdem.status!,
+        servicos: [],
+        pecas: [],
+        observacoes: this.formularioOrdem.observacoes?.trim() || undefined,
+      },
+      ...ordens,
+    ]);
+
+    this.voltarParaLista();
+  }
 
   getVeiculo(id: number) {
     return this.veiculos().find(v => v.id === id);
@@ -57,5 +265,30 @@ export class OrdensServicoComponent {
 
   getCliente(id: number) {
     return this.clientes().find(c => c.id === id);
+  }
+
+  veiculosDisponiveis() {
+    if (!this.formularioOrdem.clienteId) {
+      return this.veiculos();
+    }
+    return this.veiculos().filter(v => v.clienteId === this.formularioOrdem.clienteId);
+  }
+
+  getServico(id: number) {
+    return this.servicos().find(s => s.id === id);
+  }
+
+  getPeca(id: number) {
+    return this.pecas().find(p => p.id === id);
+  }
+
+  private limparFormulario() {
+    this.formularioOrdem = {
+      clienteId: undefined,
+      veiculoId: undefined,
+      dataEntrada: new Date().toISOString().split('T')[0],
+      status: undefined,
+      observacoes: '',
+    };
   }
 }

--- a/src/app/pages/veiculos.component.ts
+++ b/src/app/pages/veiculos.component.ts
@@ -1,49 +1,217 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { DataService } from '../core/services/data.service';
+import { Veiculo } from '../core/models/models';
 
 @Component({
   selector: 'app-veiculos',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   template: `
     <div class="bg-white p-6 rounded-lg shadow-md">
-        <div class="flex flex-col md:flex-row justify-between items-center mb-4">
-            <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Cadastro de Veículos</h2>
-            <button class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors">
-                + Cadastrar Veículo
-            </button>
-        </div>
+      <div class="flex flex-col md:flex-row justify-between items-center mb-4">
+        <h2 class="text-lg font-semibold text-gray-700 mb-4 md:mb-0">Cadastro de Veículos</h2>
+        @if (modoVisualizacao() === 'lista') {
+          <button
+            class="w-full md:w-auto bg-green-500 text-white font-bold py-2 px-4 rounded-md hover:bg-green-600 transition-colors"
+            (click)="abrirFormularioNovo()"
+          >
+            + Cadastrar Veículo
+          </button>
+        } @else {
+          <button
+            class="w-full md:w-auto bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-md hover:bg-gray-300 transition-colors"
+            (click)="voltarParaLista()"
+          >
+            Voltar para a lista
+          </button>
+        }
+      </div>
+
+      @if (modoVisualizacao() === 'lista') {
         <div class="overflow-x-auto">
-            <table class="min-w-full bg-white">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Placa</th>
-                        <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Marca</th>
-                        <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Modelo</th>
-                        <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
-                         <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
-                    </tr>
-                </thead>
-                <tbody class="text-gray-600 text-sm font-light">
-                  @for(v of veiculos(); track v.id) {
-                    <tr class="border-b border-gray-200 hover:bg-gray-50">
-                        <td class="py-3 px-6 text-left">{{v.placa}}</td>
-                        <td class="py-3 px-6 text-left">{{v.marca}}</td>
-                        <td class="py-3 px-6 text-left">{{v.modelo}}</td>
-                        <td class="py-3 px-6 text-left">{{v.clienteNome}}</td>
-                        <td class="py-3 px-6 text-center">
-                          <button class="bg-gray-200 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-300 text-xs">Editar</button>
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-            </table>
+          <table class="min-w-full bg-white">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Placa</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Marca</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Modelo</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ano</th>
+                <th class="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
+                <th class="py-3 px-6 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+              </tr>
+            </thead>
+            <tbody class="text-gray-600 text-sm font-light">
+              @for (veiculo of veiculos(); track veiculo.id) {
+                <tr class="border-b border-gray-200 hover:bg-gray-50">
+                  <td class="py-3 px-6 text-left">{{ veiculo.placa }}</td>
+                  <td class="py-3 px-6 text-left">{{ veiculo.marca }}</td>
+                  <td class="py-3 px-6 text-left">{{ veiculo.modelo }}</td>
+                  <td class="py-3 px-6 text-left">{{ veiculo.ano }}</td>
+                  <td class="py-3 px-6 text-left">{{ veiculo.clienteNome }}</td>
+                  <td class="py-3 px-6 text-center">
+                    <div class="flex justify-center gap-2">
+                      <button
+                        class="bg-gray-200 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-300 text-xs"
+                        (click)="editarVeiculo(veiculo)"
+                      >
+                        Editar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
         </div>
+      }
+
+      @if (modoVisualizacao() === 'formulario') {
+        <form class="grid gap-4 md:grid-cols-2" (ngSubmit)="salvarVeiculo()">
+          <label class="flex flex-col text-sm text-gray-600">
+            Placa
+            <input
+              class="mt-1 rounded-md border-gray-300"
+              name="placa"
+              [(ngModel)]="formulario.placa"
+              required
+              placeholder="AAA-0A00"
+            />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Marca
+            <input class="mt-1 rounded-md border-gray-300" name="marca" [(ngModel)]="formulario.marca" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Modelo
+            <input class="mt-1 rounded-md border-gray-300" name="modelo" [(ngModel)]="formulario.modelo" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600">
+            Ano
+            <input class="mt-1 rounded-md border-gray-300" name="ano" [(ngModel)]="formulario.ano" required />
+          </label>
+
+          <label class="flex flex-col text-sm text-gray-600 md:col-span-2">
+            Cliente
+            <select class="mt-1 rounded-md border-gray-300" name="clienteId" [(ngModel)]="formulario.clienteId" required>
+              <option [ngValue]="undefined" disabled>Selecione um cliente</option>
+              @for (cliente of clientes(); track cliente.id) {
+                <option [ngValue]="cliente.id">{{ cliente.nome }}</option>
+              }
+            </select>
+          </label>
+
+          <div class="md:col-span-2 flex justify-end gap-3">
+            <button type="button" class="px-4 py-2 rounded-md border border-gray-300" (click)="voltarParaLista()">Cancelar</button>
+            <button type="submit" class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">
+              {{ editandoId() ? 'Atualizar Veículo' : 'Salvar Veículo' }}
+            </button>
+          </div>
+        </form>
+      }
     </div>
   `,
 })
 export class VeiculosComponent {
   private dataService = inject(DataService);
+
   veiculos = this.dataService.veiculos;
+  clientes = this.dataService.clientes;
+
+  modoVisualizacao = signal<'lista' | 'formulario'>('lista');
+  editandoId = signal<number | null>(null);
+
+  formulario = {
+    placa: '',
+    marca: '',
+    modelo: '',
+    ano: '',
+    clienteId: undefined as number | undefined,
+  };
+
+  abrirFormularioNovo() {
+    this.editandoId.set(null);
+    this.formulario = {
+      placa: '',
+      marca: '',
+      modelo: '',
+      ano: '',
+      clienteId: undefined,
+    };
+    this.modoVisualizacao.set('formulario');
+  }
+
+  editarVeiculo(veiculo: Veiculo) {
+    this.editandoId.set(veiculo.id);
+    this.formulario = {
+      placa: veiculo.placa,
+      marca: veiculo.marca,
+      modelo: veiculo.modelo,
+      ano: veiculo.ano,
+      clienteId: veiculo.clienteId,
+    };
+    this.modoVisualizacao.set('formulario');
+  }
+
+  salvarVeiculo() {
+    if (!this.formulario.placa || !this.formulario.marca || !this.formulario.modelo || !this.formulario.ano || !this.formulario.clienteId) {
+      return;
+    }
+
+    const cliente = this.obterClienteSelecionado();
+    if (!cliente) {
+      return;
+    }
+
+    if (this.editandoId()) {
+      const idParaAtualizar = this.editandoId()!;
+      this.dataService.veiculos.update(lista =>
+        lista.map(item =>
+          item.id === idParaAtualizar
+            ? {
+                ...item,
+                placa: this.formulario.placa,
+                marca: this.formulario.marca,
+                modelo: this.formulario.modelo,
+                ano: this.formulario.ano,
+                clienteId: cliente.id,
+                clienteNome: cliente.nome,
+              }
+            : item,
+        ),
+      );
+    } else {
+      const novoId = this.dataService.veiculos().reduce((max, v) => Math.max(max, v.id), 0) + 1;
+      this.dataService.veiculos.update(lista => [
+        {
+          id: novoId,
+          placa: this.formulario.placa,
+          marca: this.formulario.marca,
+          modelo: this.formulario.modelo,
+          ano: this.formulario.ano,
+          clienteId: cliente.id,
+          clienteNome: cliente.nome,
+        },
+        ...lista,
+      ]);
+    }
+
+    this.voltarParaLista();
+  }
+
+  private obterClienteSelecionado() {
+    if (!this.formulario.clienteId) {
+      return undefined;
+    }
+    return this.clientes().find(cliente => cliente.id === this.formulario.clienteId);
+  }
+
+  voltarParaLista() {
+    this.modoVisualizacao.set('lista');
+    this.editandoId.set(null);
+  }
 }


### PR DESCRIPTION
## Summary
- replace the sidebar header block with a bespoke SVG wordmark that fills the branding strip

## Testing
- not run (npm install hangs in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e58d3c9a348321a69aaf4f95e7f3a7