### PR TITLE
feat: allow offline fallback in data layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Backend database
+server/database.sqlite

--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## Development server
 
-To start a local development server, run:
+This project now possui um backend Node.js simples responsável por persistir os dados em `server/database.json`. Para desenvolver:
 
-```bash
-ng serve
-```
+1. Em um terminal, inicie a API local:
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+   ```bash
+   npm run server
+   ```
+
+   O serviço estará disponível em `http://localhost:3000/api`.
+
+2. Em outro terminal, suba a aplicação Angular:
+
+   ```bash
+   ng serve
+   ```
+
+   Acesse `http://localhost:4200/` no navegador. As alterações nos arquivos front-end recarregam automaticamente a página.
+
+> **Evite erros no console**: Se o frontend for aberto sem a API rodando, as chamadas HTTP resultarão em mensagens de erro. O serviço de dados agora entra automaticamente em um **modo offline** e exibe informações locais somente leitura, mas para trabalhar com dados reais (e impedir as mensagens de erro) mantenha `npm run server` ativo em paralelo ao `ng serve`.
 
 ## Code scaffolding
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "server": "node server/index.js"
   },
   "prettier": {
     "printWidth": 100,

--- a/server/database.json
+++ b/server/database.json
@@ -1,0 +1,192 @@
+{
+  "clientes": [
+    {
+      "id": 1,
+      "nome": "Carlos Alberto",
+      "email": "carlos.alberto@email.com",
+      "telefone": "(11) 91234-5678"
+    },
+    {
+      "id": 2,
+      "nome": "Joana Pereira",
+      "email": "joana.pereira@email.com",
+      "telefone": "(11) 98765-4321"
+    },
+    {
+      "id": 3,
+      "nome": "Pedro Henrique",
+      "email": "pedro.henrique@email.com",
+      "telefone": "(21) 99876-5432"
+    },
+    {
+      "id": 4,
+      "nome": "João da Silva",
+      "email": "joao.silva@email.com",
+      "telefone": "(31) 93456-7890"
+    }
+  ],
+  "veiculos": [
+    {
+      "id": 1,
+      "placa": "ROZ-1295",
+      "marca": "Toyota",
+      "modelo": "Corolla",
+      "ano": "2022",
+      "clienteId": 1
+    },
+    {
+      "id": 2,
+      "placa": "PEA-0M40",
+      "marca": "Honda",
+      "modelo": "Civic",
+      "ano": "2021",
+      "clienteId": 3
+    },
+    {
+      "id": 3,
+      "placa": "LBT-3954",
+      "marca": "Ford",
+      "modelo": "Ranger",
+      "ano": "2023",
+      "clienteId": 4
+    },
+    {
+      "id": 4,
+      "placa": "XYZ-7890",
+      "marca": "Chevrolet",
+      "modelo": "Onix",
+      "ano": "2020",
+      "clienteId": 2
+    }
+  ],
+  "pecas": [
+    {
+      "id": 101,
+      "nome": "Filtro de Óleo",
+      "codigo": "FO-001",
+      "estoque": 15,
+      "preco": 35
+    },
+    {
+      "id": 102,
+      "nome": "Pastilha de Freio",
+      "codigo": "PF-002",
+      "estoque": 8,
+      "preco": 120.5
+    },
+    {
+      "id": 103,
+      "nome": "Vela de Ignição",
+      "codigo": "VI-003",
+      "estoque": 32,
+      "preco": 25
+    },
+    {
+      "id": 104,
+      "nome": "Óleo Motor 5W30",
+      "codigo": "OM-004",
+      "estoque": 20,
+      "preco": 55
+    }
+  ],
+  "servicos": [
+    {
+      "id": 201,
+      "descricao": "Troca de Óleo e Filtro",
+      "preco": 150
+    },
+    {
+      "id": 202,
+      "descricao": "Alinhamento e Balanceamento",
+      "preco": 180
+    },
+    {
+      "id": 203,
+      "descricao": "Revisão Sistema de Freios",
+      "preco": 250
+    }
+  ],
+  "ordensServico": [
+    {
+      "id": 974,
+      "clienteId": 1,
+      "veiculoId": 1,
+      "dataEntrada": "2025-09-07",
+      "status": "Em Andamento",
+      "servicos": [
+        {
+          "id": 201,
+          "qtde": 1
+        }
+      ],
+      "pecas": [
+        {
+          "id": 101,
+          "qtde": 1
+        },
+        {
+          "id": 104,
+          "qtde": 1
+        }
+      ]
+    },
+    {
+      "id": 973,
+      "clienteId": 1,
+      "veiculoId": 1,
+      "dataEntrada": "2025-09-06",
+      "status": "Finalizada",
+      "servicos": [
+        {
+          "id": 202,
+          "qtde": 1
+        }
+      ],
+      "pecas": [],
+      "observacoes": "Cliente autorizou serviços adicionais."
+    },
+    {
+      "id": 971,
+      "clienteId": 3,
+      "veiculoId": 2,
+      "dataEntrada": "2025-09-05",
+      "status": "Aguardando Aprovação",
+      "servicos": [
+        {
+          "id": 203,
+          "qtde": 1
+        }
+      ],
+      "pecas": [
+        {
+          "id": 102,
+          "qtde": 2
+        }
+      ]
+    },
+    {
+      "id": 968,
+      "clienteId": 4,
+      "veiculoId": 3,
+      "dataEntrada": "2025-09-02",
+      "status": "Finalizada",
+      "servicos": [
+        {
+          "id": 201,
+          "qtde": 1
+        }
+      ],
+      "pecas": [
+        {
+          "id": 101,
+          "qtde": 1
+        },
+        {
+          "id": 104,
+          "qtde": 1
+        }
+      ],
+      "observacoes": "Veículo entregue ao cliente."
+    }
+  ]
+}

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,235 @@
+const fs = require('fs');
+const path = require('path');
+
+const DB_FILE = path.join(__dirname, 'database.json');
+
+const defaultData = {
+  clientes: [
+    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
+    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
+    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
+    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' }
+  ],
+  veiculos: [
+    { id: 1, placa: 'ROZ-1295', marca: 'Toyota', modelo: 'Corolla', ano: '2022', clienteId: 1 },
+    { id: 2, placa: 'PEA-0M40', marca: 'Honda', modelo: 'Civic', ano: '2021', clienteId: 3 },
+    { id: 3, placa: 'LBT-3954', marca: 'Ford', modelo: 'Ranger', ano: '2023', clienteId: 4 },
+    { id: 4, placa: 'XYZ-7890', marca: 'Chevrolet', modelo: 'Onix', ano: '2020', clienteId: 2 }
+  ],
+  pecas: [
+    { id: 101, nome: 'Filtro de Óleo', codigo: 'FO-001', estoque: 15, preco: 35.0 },
+    { id: 102, nome: 'Pastilha de Freio', codigo: 'PF-002', estoque: 8, preco: 120.5 },
+    { id: 103, nome: 'Vela de Ignição', codigo: 'VI-003', estoque: 32, preco: 25.0 },
+    { id: 104, nome: 'Óleo Motor 5W30', codigo: 'OM-004', estoque: 20, preco: 55.0 }
+  ],
+  servicos: [
+    { id: 201, descricao: 'Troca de Óleo e Filtro', preco: 150.0 },
+    { id: 202, descricao: 'Alinhamento e Balanceamento', preco: 180.0 },
+    { id: 203, descricao: 'Revisão Sistema de Freios', preco: 250.0 }
+  ],
+  ordensServico: [
+    {
+      id: 974,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-07',
+      status: 'Em Andamento',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+      observacoes: undefined
+    },
+    {
+      id: 973,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-06',
+      status: 'Finalizada',
+      servicos: [{ id: 202, qtde: 1 }],
+      pecas: [],
+      observacoes: 'Cliente autorizou serviços adicionais.'
+    },
+    {
+      id: 971,
+      clienteId: 3,
+      veiculoId: 2,
+      dataEntrada: '2025-09-05',
+      status: 'Aguardando Aprovação',
+      servicos: [{ id: 203, qtde: 1 }],
+      pecas: [{ id: 102, qtde: 2 }],
+      observacoes: undefined
+    },
+    {
+      id: 968,
+      clienteId: 4,
+      veiculoId: 3,
+      dataEntrada: '2025-09-02',
+      status: 'Finalizada',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+      observacoes: 'Veículo entregue ao cliente.'
+    }
+  ]
+};
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function loadDatabase() {
+  if (!fs.existsSync(DB_FILE)) {
+    fs.writeFileSync(DB_FILE, JSON.stringify(defaultData, null, 2));
+    return clone(defaultData);
+  }
+
+  try {
+    const raw = fs.readFileSync(DB_FILE, 'utf-8');
+    if (!raw.trim()) {
+      fs.writeFileSync(DB_FILE, JSON.stringify(defaultData, null, 2));
+      return clone(defaultData);
+    }
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error('Erro ao ler banco de dados, recriando arquivo.', error);
+    fs.writeFileSync(DB_FILE, JSON.stringify(defaultData, null, 2));
+    return clone(defaultData);
+  }
+}
+
+let data = loadDatabase();
+
+function saveDatabase() {
+  fs.writeFileSync(DB_FILE, JSON.stringify(data, null, 2));
+}
+
+function getClientes() {
+  return data.clientes;
+}
+
+function getVeiculos() {
+  return data.veiculos;
+}
+
+function getPecas() {
+  return data.pecas;
+}
+
+function getServicos() {
+  return data.servicos;
+}
+
+function getOrdensServico() {
+  return data.ordensServico;
+}
+
+function nextId(collectionName) {
+  const collection = data[collectionName];
+  const maxId = collection.reduce((max, item) => (item.id > max ? item.id : max), 0);
+  return maxId + 1;
+}
+
+function addCliente(cliente) {
+  const novo = { id: nextId('clientes'), ...cliente };
+  data.clientes = [novo, ...data.clientes];
+  saveDatabase();
+  return novo;
+}
+
+function updateCliente(id, updates) {
+  let atualizado;
+  data.clientes = data.clientes.map(cliente => {
+    if (cliente.id === id) {
+      atualizado = { ...cliente, ...updates, id };
+      return atualizado;
+    }
+    return cliente;
+  });
+  if (atualizado) {
+    saveDatabase();
+  }
+  return atualizado;
+}
+
+function addVeiculo(veiculo) {
+  const novo = { id: nextId('veiculos'), ...veiculo };
+  data.veiculos = [novo, ...data.veiculos];
+  saveDatabase();
+  return novo;
+}
+
+function updateVeiculo(id, updates) {
+  let atualizado;
+  data.veiculos = data.veiculos.map(veiculo => {
+    if (veiculo.id === id) {
+      atualizado = { ...veiculo, ...updates, id };
+      return atualizado;
+    }
+    return veiculo;
+  });
+  if (atualizado) {
+    saveDatabase();
+  }
+  return atualizado;
+}
+
+function addPeca(peca) {
+  const novo = { id: nextId('pecas'), ...peca };
+  data.pecas = [novo, ...data.pecas];
+  saveDatabase();
+  return novo;
+}
+
+function updatePeca(id, updates) {
+  let atualizado;
+  data.pecas = data.pecas.map(peca => {
+    if (peca.id === id) {
+      atualizado = { ...peca, ...updates, id };
+      return atualizado;
+    }
+    return peca;
+  });
+  if (atualizado) {
+    saveDatabase();
+  }
+  return atualizado;
+}
+
+function addOrdemServico(ordem) {
+  const nova = { id: nextId('ordensServico'), servicos: [], pecas: [], ...ordem };
+  data.ordensServico = [nova, ...data.ordensServico];
+  saveDatabase();
+  return nova;
+}
+
+function updateOrdemServico(id, updates) {
+  let atualizada;
+  data.ordensServico = data.ordensServico.map(ordem => {
+    if (ordem.id === id) {
+      atualizada = { ...ordem, ...updates, id };
+      return atualizada;
+    }
+    return ordem;
+  });
+  if (atualizada) {
+    saveDatabase();
+  }
+  return atualizada;
+}
+
+module.exports = {
+  getClientes,
+  getVeiculos,
+  getPecas,
+  getServicos,
+  getOrdensServico,
+  addCliente,
+  updateCliente,
+  addVeiculo,
+  updateVeiculo,
+  addPeca,
+  updatePeca,
+  addOrdemServico,
+  updateOrdemServico,
+  nextId,
+  saveDatabase,
+  data
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,318 @@
+const http = require('http');
+const { URL } = require('url');
+const {
+  getClientes,
+  addCliente,
+  updateCliente,
+  getVeiculos,
+  addVeiculo,
+  updateVeiculo,
+  getPecas,
+  addPeca,
+  updatePeca,
+  getServicos,
+  getOrdensServico,
+  addOrdemServico,
+  updateOrdemServico
+} = require('./db');
+
+const PORT = process.env.PORT || 3000;
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function sendJson(res, status, data) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(data));
+}
+
+function parseBody(req, res, callback) {
+  const chunks = [];
+  req.on('data', chunk => chunks.push(chunk));
+  req.on('end', () => {
+    if (chunks.length === 0) {
+      callback({});
+      return;
+    }
+
+    try {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+      callback(body);
+    } catch (error) {
+      sendJson(res, 400, { message: 'JSON inválido no corpo da requisição.' });
+    }
+  });
+}
+
+function mapVeiculo(veiculo) {
+  const cliente = getClientes().find(clienteAtual => clienteAtual.id === veiculo.clienteId);
+  return {
+    ...veiculo,
+    clienteNome: cliente ? cliente.nome : 'Cliente não encontrado'
+  };
+}
+
+function mapOrdem(ordem) {
+  return {
+    ...ordem,
+    observacoes: ordem.observacoes || undefined
+  };
+}
+
+const server = http.createServer((req, res) => {
+  if (!req.url) {
+    sendJson(res, 400, { message: 'Requisição inválida.' });
+    return;
+  }
+
+  setCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const pathname = url.pathname;
+
+  try {
+    if (req.method === 'GET' && pathname === '/api/clientes') {
+      const clientes = [...getClientes()].sort((a, b) => b.id - a.id).map(cliente => ({
+        ...cliente,
+        email: cliente.email || undefined,
+        telefone: cliente.telefone || undefined
+      }));
+      sendJson(res, 200, clientes);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/clientes') {
+      parseBody(req, res, body => {
+        const { nome, email, telefone } = body || {};
+        if (!nome || !nome.trim()) {
+          sendJson(res, 400, { message: 'Nome é obrigatório.' });
+          return;
+        }
+
+        const novo = addCliente({
+          nome: nome.trim(),
+          email: email?.trim() || undefined,
+          telefone: telefone?.trim() || undefined
+        });
+        sendJson(res, 201, novo);
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/clientes\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { nome, email, telefone } = body || {};
+        if (!nome || !nome.trim()) {
+          sendJson(res, 400, { message: 'Nome é obrigatório.' });
+          return;
+        }
+        const atualizado = updateCliente(id, {
+          nome: nome.trim(),
+          email: email?.trim() || undefined,
+          telefone: telefone?.trim() || undefined
+        });
+        if (!atualizado) {
+          sendJson(res, 404, { message: 'Cliente não encontrado.' });
+          return;
+        }
+        sendJson(res, 200, atualizado);
+      });
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/veiculos') {
+      const veiculos = [...getVeiculos()].sort((a, b) => b.id - a.id).map(mapVeiculo);
+      sendJson(res, 200, veiculos);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/veiculos') {
+      parseBody(req, res, body => {
+        const { placa, marca, modelo, ano, clienteId } = body || {};
+        if (!placa || !marca || !modelo || !ano || !clienteId) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const jaExiste = getVeiculos().some(v => v.placa.toLowerCase() === placa.trim().toLowerCase());
+        if (jaExiste) {
+          sendJson(res, 409, { message: 'Já existe um veículo com esta placa.' });
+          return;
+        }
+        const novo = addVeiculo({
+          placa: placa.trim(),
+          marca: marca.trim(),
+          modelo: modelo.trim(),
+          ano: ano.trim(),
+          clienteId: Number(clienteId)
+        });
+        sendJson(res, 201, mapVeiculo(novo));
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/veiculos\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { placa, marca, modelo, ano, clienteId } = body || {};
+        if (!placa || !marca || !modelo || !ano || !clienteId) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const outroVeiculo = getVeiculos().find(v => v.placa.toLowerCase() === placa.trim().toLowerCase() && v.id !== id);
+        if (outroVeiculo) {
+          sendJson(res, 409, { message: 'Já existe um veículo com esta placa.' });
+          return;
+        }
+        const atualizado = updateVeiculo(id, {
+          placa: placa.trim(),
+          marca: marca.trim(),
+          modelo: modelo.trim(),
+          ano: ano.trim(),
+          clienteId: Number(clienteId)
+        });
+        if (!atualizado) {
+          sendJson(res, 404, { message: 'Veículo não encontrado.' });
+          return;
+        }
+        sendJson(res, 200, mapVeiculo(atualizado));
+      });
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/pecas') {
+      const pecas = [...getPecas()].sort((a, b) => b.id - a.id);
+      sendJson(res, 200, pecas);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/pecas') {
+      parseBody(req, res, body => {
+        const { nome, codigo, estoque, preco } = body || {};
+        if (!nome || !codigo) {
+          sendJson(res, 400, { message: 'Nome e código são obrigatórios.' });
+          return;
+        }
+        const novo = addPeca({
+          nome: nome.trim(),
+          codigo: codigo.trim(),
+          estoque: Number.isFinite(Number(estoque)) ? Number(estoque) : 0,
+          preco: Number.isFinite(Number(preco)) ? Number(preco) : 0
+        });
+        sendJson(res, 201, novo);
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/pecas\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { nome, codigo, estoque, preco } = body || {};
+        if (!nome || !codigo) {
+          sendJson(res, 400, { message: 'Nome e código são obrigatórios.' });
+          return;
+        }
+        const atualizada = updatePeca(id, {
+          nome: nome.trim(),
+          codigo: codigo.trim(),
+          estoque: Number.isFinite(Number(estoque)) ? Number(estoque) : 0,
+          preco: Number.isFinite(Number(preco)) ? Number(preco) : 0
+        });
+        if (!atualizada) {
+          sendJson(res, 404, { message: 'Peça não encontrada.' });
+          return;
+        }
+        sendJson(res, 200, atualizada);
+      });
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/servicos') {
+      const servicos = [...getServicos()].sort((a, b) => b.id - a.id);
+      sendJson(res, 200, servicos);
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/ordens-servico') {
+      const ordens = [...getOrdensServico()].sort((a, b) => b.id - a.id).map(mapOrdem);
+      sendJson(res, 200, ordens);
+      return;
+    }
+
+    if (req.method === 'GET' && /^\/api\/ordens-servico\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      const ordem = getOrdensServico().find(item => item.id === id);
+      if (!ordem) {
+        sendJson(res, 404, { message: 'Ordem de serviço não encontrada.' });
+        return;
+      }
+      sendJson(res, 200, mapOrdem(ordem));
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/ordens-servico') {
+      parseBody(req, res, body => {
+        const { clienteId, veiculoId, dataEntrada, status, servicos = [], pecas = [], observacoes } = body || {};
+        if (!clienteId || !veiculoId || !dataEntrada || !status) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const nova = addOrdemServico({
+          clienteId: Number(clienteId),
+          veiculoId: Number(veiculoId),
+          dataEntrada,
+          status,
+          servicos: Array.isArray(servicos) ? servicos : [],
+          pecas: Array.isArray(pecas) ? pecas : [],
+          observacoes: observacoes?.trim() || undefined
+        });
+        sendJson(res, 201, mapOrdem(nova));
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/ordens-servico\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { clienteId, veiculoId, dataEntrada, status, servicos = [], pecas = [], observacoes } = body || {};
+        if (!clienteId || !veiculoId || !dataEntrada || !status) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const atualizada = updateOrdemServico(id, {
+          clienteId: Number(clienteId),
+          veiculoId: Number(veiculoId),
+          dataEntrada,
+          status,
+          servicos: Array.isArray(servicos) ? servicos : [],
+          pecas: Array.isArray(pecas) ? pecas : [],
+          observacoes: observacoes?.trim() || undefined
+        });
+        if (!atualizada) {
+          sendJson(res, 404, { message: 'Ordem de serviço não encontrada.' });
+          return;
+        }
+        sendJson(res, 200, mapOrdem(atualizada));
+      });
+      return;
+    }
+
+    sendJson(res, 404, { message: 'Rota não encontrada.' });
+  } catch (error) {
+    console.error('Erro inesperado:', error);
+    sendJson(res, 500, { message: 'Erro interno do servidor.' });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Servidor da API iniciado em http://localhost:${PORT}`);
+});

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,8 @@
 import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes)]
+  providers: [provideRouter(routes), provideHttpClient()]
 };

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,83 +1,510 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { Cliente, OrdemServico, Peca, Servico, Veiculo } from '../models/models';
+
+type OfflineDatabase = {
+  clientes: Cliente[];
+  veiculos: Veiculo[];
+  pecas: Peca[];
+  servicos: Servico[];
+  ordensServico: OrdemServico[];
+};
+
+const OFFLINE_DATA: OfflineDatabase = {
+  clientes: [
+    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
+    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
+    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
+    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' }
+  ],
+  veiculos: [
+    { id: 1, placa: 'ROZ-1295', marca: 'Toyota', modelo: 'Corolla', ano: '2022', clienteId: 1, clienteNome: 'Carlos Alberto' },
+    { id: 2, placa: 'PEA-0M40', marca: 'Honda', modelo: 'Civic', ano: '2021', clienteId: 3, clienteNome: 'Pedro Henrique' },
+    { id: 3, placa: 'LBT-3954', marca: 'Ford', modelo: 'Ranger', ano: '2023', clienteId: 4, clienteNome: 'João da Silva' },
+    { id: 4, placa: 'XYZ-7890', marca: 'Chevrolet', modelo: 'Onix', ano: '2020', clienteId: 2, clienteNome: 'Joana Pereira' }
+  ],
+  pecas: [
+    { id: 101, nome: 'Filtro de Óleo', codigo: 'FO-001', estoque: 15, preco: 35 },
+    { id: 102, nome: 'Pastilha de Freio', codigo: 'PF-002', estoque: 8, preco: 120.5 },
+    { id: 103, nome: 'Vela de Ignição', codigo: 'VI-003', estoque: 32, preco: 25 },
+    { id: 104, nome: 'Óleo Motor 5W30', codigo: 'OM-004', estoque: 20, preco: 55 }
+  ],
+  servicos: [
+    { id: 201, descricao: 'Troca de Óleo e Filtro', preco: 150 },
+    { id: 202, descricao: 'Alinhamento e Balanceamento', preco: 180 },
+    { id: 203, descricao: 'Revisão Sistema de Freios', preco: 250 }
+  ],
+  ordensServico: [
+    {
+      id: 974,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-07',
+      status: 'Em Andamento',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }]
+    },
+    {
+      id: 973,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-06',
+      status: 'Finalizada',
+      servicos: [{ id: 202, qtde: 1 }],
+      pecas: [],
+      observacoes: 'Cliente autorizou serviços adicionais.'
+    },
+    {
+      id: 971,
+      clienteId: 3,
+      veiculoId: 2,
+      dataEntrada: '2025-09-05',
+      status: 'Aguardando Aprovação',
+      servicos: [{ id: 203, qtde: 1 }],
+      pecas: [{ id: 102, qtde: 2 }]
+    },
+    {
+      id: 968,
+      clienteId: 4,
+      veiculoId: 3,
+      dataEntrada: '2025-09-02',
+      status: 'Finalizada',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+      observacoes: 'Veículo entregue ao cliente.'
+    }
+  ]
+};
+
+const deepClone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const sortByIdDesc = <T extends { id: number }>(lista: T[]): T[] => [...lista].sort((a, b) => b.id - a.id);
 
 @Injectable({
   providedIn: 'root'
 })
 export class DataService {
+  private http = inject(HttpClient);
+  private readonly apiUrl = 'http://localhost:3000/api';
+  private readonly offlineState: OfflineDatabase = deepClone(OFFLINE_DATA);
 
-  // --- DADOS MOCKADOS (Simulação de um banco de dados) ---
-  // Usando Signals para reatividade.
-  
-  readonly clientes = signal<Cliente[]>([
-    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
-    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
-    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
-    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' },
-  ]);
+  readonly clientes = signal<Cliente[]>([]);
+  readonly veiculos = signal<Veiculo[]>([]);
+  readonly pecas = signal<Peca[]>([]);
+  readonly servicos = signal<Servico[]>([]);
+  readonly ordensServico = signal<OrdemServico[]>([]);
+  readonly modoOffline = signal(false);
 
-  readonly veiculos = signal<Veiculo[]>([
-    { id: 1, placa: 'ROZ-1295', marca: 'Toyota', modelo: 'Corolla', ano: '2022', clienteId: 1, clienteNome: 'Carlos Alberto' },
-    { id: 2, placa: 'PEA-0M40', marca: 'Honda', modelo: 'Civic', ano: '2021', clienteId: 3, clienteNome: 'Pedro Henrique' },
-    { id: 3, placa: 'LBT-3954', marca: 'Ford', modelo: 'Ranger', ano: '2023', clienteId: 4, clienteNome: 'João da Silva' },
-    { id: 4, placa: 'XYZ-7890', marca: 'Chevrolet', modelo: 'Onix', ano: '2020', clienteId: 2, clienteNome: 'Joana Pereira' },
-  ]);
+  constructor() {
+    void this.carregarDadosIniciais();
+  }
 
-  readonly pecas = signal<Peca[]>([
-    { id: 101, nome: 'Filtro de Óleo', codigo: 'FO-001', estoque: 15, preco: 35.00 },
-    { id: 102, nome: 'Pastilha de Freio', codigo: 'PF-002', estoque: 8, preco: 120.50 },
-    { id: 103, nome: 'Vela de Ignição', codigo: 'VI-003', estoque: 32, preco: 25.00 },
-    { id: 104, nome: 'Óleo Motor 5W30', codigo: 'OM-004', estoque: 20, preco: 55.00 },
-  ]);
+  async carregarDadosIniciais() {
+    await Promise.all([
+      this.carregarClientes(),
+      this.carregarVeiculos(),
+      this.carregarPecas(),
+      this.carregarServicos(),
+      this.carregarOrdensServico(),
+    ]);
+  }
 
-  readonly servicos = signal<Servico[]>([
-    { id: 201, descricao: 'Troca de Óleo e Filtro', preco: 150.00 },
-    { id: 202, descricao: 'Alinhamento e Balanceamento', preco: 180.00 },
-    { id: 203, descricao: 'Revisão Sistema de Freios', preco: 250.00 },
-  ]);
+  async carregarClientes() {
+    if (this.modoOffline()) {
+      this.reaplicarClientesOffline();
+      return;
+    }
+    try {
+      const clientes = await firstValueFrom(this.http.get<Cliente[]>(`${this.apiUrl}/clientes`));
+      this.atualizarClientes(clientes);
+    } catch (error) {
+      console.error('Erro ao carregar clientes', error);
+      this.ativarModoOffline();
+    }
+  }
 
-  readonly ordensServico = signal<OrdemServico[]>([
-    {
-      id: 974,
-      veiculoId: 1,
-      clienteId: 1,
-      dataEntrada: '2025-09-07',
-      status: 'Em Andamento',
-      servicos: [{ id: 201, qtde: 1 }],
-      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
-    },
-    {
-      id: 973,
-      veiculoId: 1,
-      clienteId: 1,
-      dataEntrada: '2025-09-06',
-      status: 'Finalizada',
-      servicos: [{ id: 202, qtde: 1 }],
-      pecas: [],
-    },
-    {
-      id: 971,
-      veiculoId: 2,
-      clienteId: 3,
-      dataEntrada: '2025-09-05',
-      status: 'Aguardando Aprovação',
-      servicos: [{ id: 203, qtde: 1 }],
-      pecas: [{ id: 102, qtde: 2 }],
-    },
-    {
-      id: 968,
-      veiculoId: 3,
-      clienteId: 4,
-      dataEntrada: '2025-09-02',
-      status: 'Finalizada',
-      servicos: [{ id: 201, qtde: 1 }],
-      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
-    },
-  ]);
+  async criarCliente(dados: Omit<Cliente, 'id'>) {
+    if (this.modoOffline()) {
+      return this.criarClienteOffline(dados);
+    }
 
-  constructor() { }
+    try {
+      const novo = await firstValueFrom(this.http.post<Cliente>(`${this.apiUrl}/clientes`, dados));
+      this.clientes.update(lista => [novo, ...lista.filter(cliente => cliente.id !== novo.id)]);
+      this.offlineState.clientes = deepClone(this.clientes());
+      return novo;
+    } catch (error) {
+      console.error('Erro ao criar cliente', error);
+      this.ativarModoOffline();
+      return this.criarClienteOffline(dados);
+    }
+  }
+
+  async atualizarCliente(id: number, dados: Omit<Cliente, 'id'>) {
+    if (this.modoOffline()) {
+      return this.atualizarClienteOffline(id, dados);
+    }
+
+    try {
+      const atualizado = await firstValueFrom(this.http.put<Cliente>(`${this.apiUrl}/clientes/${id}`, dados));
+      this.clientes.update(lista => lista.map(cliente => (cliente.id === id ? atualizado : cliente)));
+      this.offlineState.clientes = deepClone(this.clientes());
+      await this.carregarVeiculos();
+      return atualizado;
+    } catch (error) {
+      console.error('Erro ao atualizar cliente', error);
+      this.ativarModoOffline();
+      return this.atualizarClienteOffline(id, dados);
+    }
+  }
+
+  async carregarVeiculos() {
+    if (this.modoOffline()) {
+      this.reaplicarVeiculosOffline();
+      return;
+    }
+    try {
+      const veiculos = await firstValueFrom(this.http.get<Veiculo[]>(`${this.apiUrl}/veiculos`));
+      this.atualizarVeiculos(veiculos);
+    } catch (error) {
+      console.error('Erro ao carregar veículos', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async criarVeiculo(dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    if (this.modoOffline()) {
+      return this.criarVeiculoOffline(dados);
+    }
+
+    try {
+      const novo = await firstValueFrom(this.http.post<Veiculo>(`${this.apiUrl}/veiculos`, dados));
+      this.veiculos.update(lista => [novo, ...lista.filter(veiculo => veiculo.id !== novo.id)]);
+      this.offlineState.veiculos = deepClone(this.veiculos());
+      return novo;
+    } catch (error) {
+      console.error('Erro ao criar veículo', error);
+      this.ativarModoOffline();
+      return this.criarVeiculoOffline(dados);
+    }
+  }
+
+  async atualizarVeiculo(id: number, dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    if (this.modoOffline()) {
+      return this.atualizarVeiculoOffline(id, dados);
+    }
+
+    try {
+      const atualizado = await firstValueFrom(this.http.put<Veiculo>(`${this.apiUrl}/veiculos/${id}`, dados));
+      this.veiculos.update(lista => lista.map(veiculo => (veiculo.id === id ? atualizado : veiculo)));
+      this.offlineState.veiculos = deepClone(this.veiculos());
+      return atualizado;
+    } catch (error) {
+      console.error('Erro ao atualizar veículo', error);
+      this.ativarModoOffline();
+      return this.atualizarVeiculoOffline(id, dados);
+    }
+  }
+
+  async carregarPecas() {
+    if (this.modoOffline()) {
+      this.reaplicarPecasOffline();
+      return;
+    }
+    try {
+      const pecas = await firstValueFrom(this.http.get<Peca[]>(`${this.apiUrl}/pecas`));
+      this.atualizarPecas(pecas);
+    } catch (error) {
+      console.error('Erro ao carregar peças', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async criarPeca(dados: Omit<Peca, 'id'>) {
+    if (this.modoOffline()) {
+      return this.criarPecaOffline(dados);
+    }
+
+    try {
+      const nova = await firstValueFrom(this.http.post<Peca>(`${this.apiUrl}/pecas`, dados));
+      this.pecas.update(lista => [nova, ...lista.filter(peca => peca.id !== nova.id)]);
+      this.offlineState.pecas = deepClone(this.pecas());
+      return nova;
+    } catch (error) {
+      console.error('Erro ao criar peça', error);
+      this.ativarModoOffline();
+      return this.criarPecaOffline(dados);
+    }
+  }
+
+  async atualizarPeca(id: number, dados: Omit<Peca, 'id'>) {
+    if (this.modoOffline()) {
+      return this.atualizarPecaOffline(id, dados);
+    }
+
+    try {
+      const atualizada = await firstValueFrom(this.http.put<Peca>(`${this.apiUrl}/pecas/${id}`, dados));
+      this.pecas.update(lista => lista.map(peca => (peca.id === id ? atualizada : peca)));
+      this.offlineState.pecas = deepClone(this.pecas());
+      return atualizada;
+    } catch (error) {
+      console.error('Erro ao atualizar peça', error);
+      this.ativarModoOffline();
+      return this.atualizarPecaOffline(id, dados);
+    }
+  }
+
+  async carregarServicos() {
+    if (this.modoOffline()) {
+      this.reaplicarServicosOffline();
+      return;
+    }
+    try {
+      const servicos = await firstValueFrom(this.http.get<Servico[]>(`${this.apiUrl}/servicos`));
+      this.atualizarServicos(servicos);
+    } catch (error) {
+      console.error('Erro ao carregar serviços', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async carregarOrdensServico() {
+    if (this.modoOffline()) {
+      this.reaplicarOrdensOffline();
+      return;
+    }
+    try {
+      const ordens = await firstValueFrom(this.http.get<OrdemServico[]>(`${this.apiUrl}/ordens-servico`));
+      this.atualizarOrdens(ordens);
+    } catch (error) {
+      console.error('Erro ao carregar ordens de serviço', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async criarOrdemServico(dados: Omit<OrdemServico, 'id'>) {
+    if (this.modoOffline()) {
+      return this.criarOrdemOffline(dados);
+    }
+
+    try {
+      const nova = await firstValueFrom(this.http.post<OrdemServico>(`${this.apiUrl}/ordens-servico`, dados));
+      this.ordensServico.update(lista => [nova, ...lista.filter(ordem => ordem.id !== nova.id)]);
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+      return nova;
+    } catch (error) {
+      console.error('Erro ao criar ordem de serviço', error);
+      this.ativarModoOffline();
+      return this.criarOrdemOffline(dados);
+    }
+  }
+
+  async atualizarOrdemServico(id: number, dados: Omit<OrdemServico, 'id'>) {
+    if (this.modoOffline()) {
+      return this.atualizarOrdemOffline(id, dados);
+    }
+
+    try {
+      const atualizada = await firstValueFrom(this.http.put<OrdemServico>(`${this.apiUrl}/ordens-servico/${id}`, dados));
+      this.ordensServico.update(lista => lista.map(ordem => (ordem.id === id ? atualizada : ordem)));
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+      return atualizada;
+    } catch (error) {
+      console.error('Erro ao atualizar ordem de serviço', error);
+      this.ativarModoOffline();
+      return this.atualizarOrdemOffline(id, dados);
+    }
+  }
 
   getOrdemServicoById(id: number): OrdemServico | undefined {
     return this.ordensServico().find(os => os.id === id);
+  }
+
+  private ativarModoOffline() {
+    if (this.modoOffline()) {
+      return;
+    }
+    this.modoOffline.set(true);
+    console.warn('API indisponível. Entrando em modo offline com dados locais.');
+    this.reaplicarClientesOffline();
+    this.reaplicarVeiculosOffline();
+    this.reaplicarPecasOffline();
+    this.reaplicarServicosOffline();
+    this.reaplicarOrdensOffline();
+  }
+
+  private gerarProximoId(lista: { id: number }[]) {
+    return lista.reduce((max, item) => (item.id > max ? item.id : max), 0) + 1;
+  }
+
+  private reaplicarClientesOffline() {
+    this.clientes.set(sortByIdDesc(deepClone(this.offlineState.clientes)));
+  }
+
+  private reaplicarVeiculosOffline() {
+    this.veiculos.set(sortByIdDesc(deepClone(this.offlineState.veiculos)));
+  }
+
+  private reaplicarPecasOffline() {
+    this.pecas.set(sortByIdDesc(deepClone(this.offlineState.pecas)));
+  }
+
+  private reaplicarServicosOffline() {
+    this.servicos.set(sortByIdDesc(deepClone(this.offlineState.servicos)));
+  }
+
+  private reaplicarOrdensOffline() {
+    this.ordensServico.set(sortByIdDesc(deepClone(this.offlineState.ordensServico)));
+  }
+
+  private atualizarClientes(clientes: Cliente[]) {
+    const ordenados = sortByIdDesc(clientes);
+    const copiados = deepClone(ordenados);
+    this.clientes.set(copiados);
+    this.offlineState.clientes = deepClone(copiados);
+  }
+
+  private atualizarVeiculos(veiculos: Veiculo[]) {
+    const ordenados = sortByIdDesc(veiculos);
+    const copiados = deepClone(ordenados);
+    this.veiculos.set(copiados);
+    this.offlineState.veiculos = deepClone(copiados);
+  }
+
+  private atualizarPecas(pecas: Peca[]) {
+    const ordenadas = sortByIdDesc(pecas);
+    const copiadas = deepClone(ordenadas);
+    this.pecas.set(copiadas);
+    this.offlineState.pecas = deepClone(copiadas);
+  }
+
+  private atualizarServicos(servicos: Servico[]) {
+    const ordenados = sortByIdDesc(servicos);
+    const copiados = deepClone(ordenados);
+    this.servicos.set(copiados);
+    this.offlineState.servicos = deepClone(copiados);
+  }
+
+  private atualizarOrdens(ordens: OrdemServico[]) {
+    const ordenadas = sortByIdDesc(ordens);
+    const copiadas = deepClone(ordenadas);
+    this.ordensServico.set(copiadas);
+    this.offlineState.ordensServico = deepClone(copiadas);
+  }
+
+  private criarClienteOffline(dados: Omit<Cliente, 'id'>) {
+    const novo: Cliente = { id: this.gerarProximoId(this.offlineState.clientes), ...dados };
+    const atualizados = [novo, ...this.offlineState.clientes];
+    this.atualizarClientes(atualizados);
+    this.atualizarVeiculos(
+      this.offlineState.veiculos.map(veiculo =>
+        veiculo.clienteId === novo.id ? { ...veiculo, clienteNome: novo.nome } : veiculo
+      )
+    );
+    return novo;
+  }
+
+  private atualizarClienteOffline(id: number, dados: Omit<Cliente, 'id'>) {
+    let atualizado: Cliente | undefined;
+    const atualizados = this.offlineState.clientes.map(cliente => {
+      if (cliente.id === id) {
+        atualizado = { ...cliente, ...dados };
+        return atualizado;
+      }
+      return cliente;
+    });
+    if (!atualizado) {
+      return undefined;
+    }
+    this.atualizarClientes(atualizados);
+    this.atualizarVeiculos(
+      this.offlineState.veiculos.map(veiculo =>
+        veiculo.clienteId === id ? { ...veiculo, clienteNome: atualizado!.nome } : veiculo
+      )
+    );
+    return atualizado;
+  }
+
+  private criarVeiculoOffline(dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    const cliente = this.clientes().find(item => item.id === dados.clienteId);
+    const novo: Veiculo = {
+      id: this.gerarProximoId(this.offlineState.veiculos),
+      ...dados,
+      clienteNome: cliente ? cliente.nome : 'Cliente não encontrado'
+    };
+    const atualizados = [novo, ...this.offlineState.veiculos];
+    this.atualizarVeiculos(atualizados);
+    return novo;
+  }
+
+  private atualizarVeiculoOffline(id: number, dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    const cliente = this.clientes().find(item => item.id === dados.clienteId);
+    let atualizado: Veiculo | undefined;
+    const atualizados = this.offlineState.veiculos.map(veiculo => {
+      if (veiculo.id === id) {
+        atualizado = {
+          ...veiculo,
+          ...dados,
+          clienteNome: cliente ? cliente.nome : 'Cliente não encontrado'
+        };
+        return atualizado;
+      }
+      return veiculo;
+    });
+    if (!atualizado) {
+      return undefined;
+    }
+    this.atualizarVeiculos(atualizados);
+    return atualizado;
+  }
+
+  private criarPecaOffline(dados: Omit<Peca, 'id'>) {
+    const nova: Peca = { id: this.gerarProximoId(this.offlineState.pecas), ...dados };
+    const atualizadas = [nova, ...this.offlineState.pecas];
+    this.atualizarPecas(atualizadas);
+    return nova;
+  }
+
+  private atualizarPecaOffline(id: number, dados: Omit<Peca, 'id'>) {
+    let atualizada: Peca | undefined;
+    const atualizadas = this.offlineState.pecas.map(peca => {
+      if (peca.id === id) {
+        atualizada = { ...peca, ...dados };
+        return atualizada;
+      }
+      return peca;
+    });
+    if (!atualizada) {
+      return undefined;
+    }
+    this.atualizarPecas(atualizadas);
+    return atualizada;
+  }
+
+  private criarOrdemOffline(dados: Omit<OrdemServico, 'id'>) {
+    const nova: OrdemServico = {
+      id: this.gerarProximoId(this.offlineState.ordensServico),
+      ...deepClone(dados)
+    };
+    const atualizadas = [nova, ...this.offlineState.ordensServico];
+    this.atualizarOrdens(atualizadas);
+    return nova;
+  }
+
+  private atualizarOrdemOffline(id: number, dados: Omit<OrdemServico, 'id'>) {
+    let atualizada: OrdemServico | undefined;
+    const atualizadas = this.offlineState.ordensServico.map(ordem => {
+      if (ordem.id === id) {
+        atualizada = { ...ordem, ...deepClone(dados) };
+        return atualizada;
+      }
+      return ordem;
+    });
+    if (!atualizada) {
+      return undefined;
+    }
+    this.atualizarOrdens(atualizadas);
+    return atualizada;
   }
 }

--- a/src/app/pages/clientes.component.ts
+++ b/src/app/pages/clientes.component.ts
@@ -230,35 +230,27 @@ export class ClientesComponent {
     this.modoVisualizacao.set('detalhes');
   }
 
-  salvarCliente() {
+  async salvarCliente() {
     if (!this.formulario.nome || !this.formulario.email || !this.formulario.telefone) {
       return;
     }
 
     const dadosNormalizados = {
       nome: this.formulario.nome.trim(),
-      email: this.formulario.email.trim(),
-      telefone: this.formulario.telefone.trim(),
+      email: this.formulario.email.trim() || undefined,
+      telefone: this.formulario.telefone.trim() || undefined,
     };
 
-    if (this.editandoId()) {
-      const idParaAtualizar = this.editandoId()!;
-      this.dataService.clientes.update(lista =>
-        lista.map(item =>
-          item.id === idParaAtualizar
-            ? { ...item, ...dadosNormalizados }
-            : item,
-        ),
-      );
-    } else {
-      const novoId = this.dataService.clientes().reduce((max, cliente) => Math.max(max, cliente.id), 0) + 1;
-      this.dataService.clientes.update(lista => [
-        { id: novoId, ...dadosNormalizados },
-        ...lista,
-      ]);
+    try {
+      if (this.editandoId()) {
+        await this.dataService.atualizarCliente(this.editandoId()!, dadosNormalizados);
+      } else {
+        await this.dataService.criarCliente(dadosNormalizados);
+      }
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao salvar cliente', error);
     }
-
-    this.voltarParaLista();
   }
 
   voltarParaLista() {

--- a/src/app/pages/estoque.component.ts
+++ b/src/app/pages/estoque.component.ts
@@ -178,41 +178,28 @@ export class EstoqueComponent {
     this.modoVisualizacao.set('formulario');
   }
 
-  salvarPeca() {
+  async salvarPeca() {
     if (!this.formulario.codigo || !this.formulario.nome) {
       return;
     }
 
-    if (this.editandoId()) {
-      const idParaAtualizar = this.editandoId()!;
-      this.dataService.pecas.update(lista =>
-        lista.map(item =>
-          item.id === idParaAtualizar
-            ? {
-                ...item,
-                codigo: this.formulario.codigo,
-                nome: this.formulario.nome,
-                estoque: Number(this.formulario.estoque),
-                preco: Number(this.formulario.preco),
-              }
-            : item,
-        ),
-      );
-    } else {
-      const novoId = this.dataService.pecas().reduce((max, peca) => Math.max(max, peca.id), 0) + 1;
-      this.dataService.pecas.update(lista => [
-        {
-          id: novoId,
-          codigo: this.formulario.codigo,
-          nome: this.formulario.nome,
-          estoque: Number(this.formulario.estoque),
-          preco: Number(this.formulario.preco),
-        },
-        ...lista,
-      ]);
-    }
+    const dados = {
+      codigo: this.formulario.codigo.trim(),
+      nome: this.formulario.nome.trim(),
+      estoque: Number(this.formulario.estoque),
+      preco: Number(this.formulario.preco),
+    };
 
-    this.voltarParaLista();
+    try {
+      if (this.editandoId()) {
+        await this.dataService.atualizarPeca(this.editandoId()!, dados);
+      } else {
+        await this.dataService.criarPeca(dados);
+      }
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao salvar peça', error);
+    }
   }
 
   voltarParaLista() {

--- a/src/app/pages/ordens-servico.component.ts
+++ b/src/app/pages/ordens-servico.component.ts
@@ -284,27 +284,27 @@ export class OrdensServicoComponent {
     this.ordemSelecionadaId.set(null);
   }
 
-  salvarOrdem() {
+  async salvarOrdem() {
     if (!this.formularioOrdem.clienteId || !this.formularioOrdem.veiculoId || !this.formularioOrdem.dataEntrada || !this.formularioOrdem.status) {
       return;
     }
 
-    const novaOrdemId = this.ordensServico().reduce((max, os) => Math.max(max, os.id), 0) + 1;
-    this.dataService.ordensServico.update(ordens => [
-      {
-        id: novaOrdemId,
-        clienteId: this.formularioOrdem.clienteId!,
-        veiculoId: this.formularioOrdem.veiculoId!,
-        dataEntrada: this.formularioOrdem.dataEntrada,
-        status: this.formularioOrdem.status!,
-        servicos: [],
-        pecas: [],
-        observacoes: this.formularioOrdem.observacoes?.trim() || undefined,
-      },
-      ...ordens,
-    ]);
+    const dados = {
+      clienteId: this.formularioOrdem.clienteId!,
+      veiculoId: this.formularioOrdem.veiculoId!,
+      dataEntrada: this.formularioOrdem.dataEntrada,
+      status: this.formularioOrdem.status!,
+      servicos: [],
+      pecas: [],
+      observacoes: this.formularioOrdem.observacoes?.trim() || undefined,
+    };
 
-    this.voltarParaLista();
+    try {
+      await this.dataService.criarOrdemServico(dados);
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao salvar ordem de serviço', error);
+    }
   }
 
   getVeiculo(id: number) {

--- a/src/app/pages/veiculos.component.ts
+++ b/src/app/pages/veiculos.component.ts
@@ -195,7 +195,7 @@ export class VeiculosComponent {
     this.modoVisualizacao.set('formulario');
   }
 
-  salvarVeiculo() {
+  async salvarVeiculo() {
     if (!this.formulario.placa || !this.formulario.marca || !this.formulario.modelo || !this.formulario.ano || !this.formulario.clienteId) {
       return;
     }
@@ -205,40 +205,24 @@ export class VeiculosComponent {
       return;
     }
 
-    if (this.editandoId()) {
-      const idParaAtualizar = this.editandoId()!;
-      this.dataService.veiculos.update(lista =>
-        lista.map(item =>
-          item.id === idParaAtualizar
-            ? {
-                ...item,
-                placa: this.formulario.placa,
-                marca: this.formulario.marca,
-                modelo: this.formulario.modelo,
-                ano: this.formulario.ano,
-                clienteId: cliente.id,
-                clienteNome: cliente.nome,
-              }
-            : item,
-        ),
-      );
-    } else {
-      const novoId = this.dataService.veiculos().reduce((max, v) => Math.max(max, v.id), 0) + 1;
-      this.dataService.veiculos.update(lista => [
-        {
-          id: novoId,
-          placa: this.formulario.placa,
-          marca: this.formulario.marca,
-          modelo: this.formulario.modelo,
-          ano: this.formulario.ano,
-          clienteId: cliente.id,
-          clienteNome: cliente.nome,
-        },
-        ...lista,
-      ]);
-    }
+    const dados = {
+      placa: this.formulario.placa.trim(),
+      marca: this.formulario.marca.trim(),
+      modelo: this.formulario.modelo.trim(),
+      ano: this.formulario.ano.trim(),
+      clienteId: cliente.id,
+    };
 
-    this.voltarParaLista();
+    try {
+      if (this.editandoId()) {
+        await this.dataService.atualizarVeiculo(this.editandoId()!, dados);
+      } else {
+        await this.dataService.criarVeiculo(dados);
+      }
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao salvar veículo', error);
+    }
   }
 
   private obterClienteSelecionado() {


### PR DESCRIPTION
## Summary
- add an offline cache with seeded data to the Angular data service so the UI can keep working when the API is unavailable
- fall back to the cached collections for all CRUD operations and resync the cache whenever online requests succeed
- document the new offline behaviour in the README so developers know how to avoid console errors by running the API

## Testing
- npm run build *(fails: Angular CLI binaries are not installed because npm install is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eaede5540483219d95a4a69408a9c3