### PR TITLE
feat: secure login and enhance workshop operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Backend database
+server/database.sqlite

--- a/README.md
+++ b/README.md
@@ -4,13 +4,37 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## Development server
 
-To start a local development server, run:
+This project now possui um backend Node.js simples responsável por persistir os dados em `server/database.json`. Para desenvolver:
 
-```bash
-ng serve
-```
+1. Em um terminal, inicie a API local:
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+   ```bash
+   npm run server
+   ```
+
+   O serviço estará disponível em `http://localhost:3000/api`.
+
+2. Em outro terminal, suba a aplicação Angular:
+
+   ```bash
+   ng serve
+   ```
+
+   Acesse `http://localhost:4200/` no navegador. As alterações nos arquivos front-end recarregam automaticamente a página.
+
+> **Evite erros no console**: Se o frontend for aberto sem a API rodando, as chamadas HTTP resultarão em mensagens de erro. O serviço de dados agora entra automaticamente em um **modo offline** e exibe informações locais somente leitura, mas para trabalhar com dados reais (e impedir as mensagens de erro) mantenha `npm run server` ativo em paralelo ao `ng serve`.
+
+### Credenciais padrão
+
+Para testar o fluxo completo de autenticação foi incluído um usuário administrador:
+
+| Perfil | E-mail | Senha |
+| ------ | ------ | ----- |
+| Admin | `admin@oficinapro.com` | `admin123` |
+
+Também existe um usuário de atendimento (`atendimento@oficinapro.com` / `atendimento123`) que pode ser utilizado para cenários de demonstração.
+
+Após o login, todos os módulos de clientes, veículos, estoque e ordens de serviço passam a permitir pesquisa instantânea, impressão do resumo de cada ordem e exclusão segura de registros diretamente pela interface.
 
 ## Code scaffolding
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project now possui um backend Node.js simples responsável por persistir os
 
    Acesse `http://localhost:4200/` no navegador. As alterações nos arquivos front-end recarregam automaticamente a página.
 
-> **Evite erros no console**: Se o frontend for aberto sem a API rodando, as chamadas HTTP resultarão em mensagens de erro. O serviço de dados agora entra automaticamente em um **modo offline** e exibe informações locais somente leitura, mas para trabalhar com dados reais (e impedir as mensagens de erro) mantenha `npm run server` ativo em paralelo ao `ng serve`.
+> **Evite erros no console**: Se o frontend for aberto sem a API rodando, ele detecta automaticamente a indisponibilidade do servidor, entra em **modo offline** e utiliza os dados locais sem disparar erros de `ERR_CONNECTION_REFUSED`. Para trabalhar com dados persistidos mantenha `npm run server` ativo em paralelo ao `ng serve`.
 
 ### Credenciais padrão
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "server": "node server/index.js"
   },
   "prettier": {
     "printWidth": 100,

--- a/server/database.json
+++ b/server/database.json
@@ -1,0 +1,208 @@
+{
+  "clientes": [
+    {
+      "id": 1,
+      "nome": "Carlos Alberto",
+      "email": "carlos.alberto@email.com",
+      "telefone": "(11) 91234-5678"
+    },
+    {
+      "id": 2,
+      "nome": "Joana Pereira",
+      "email": "joana.pereira@email.com",
+      "telefone": "(11) 98765-4321"
+    },
+    {
+      "id": 3,
+      "nome": "Pedro Henrique",
+      "email": "pedro.henrique@email.com",
+      "telefone": "(21) 99876-5432"
+    },
+    {
+      "id": 4,
+      "nome": "João da Silva",
+      "email": "joao.silva@email.com",
+      "telefone": "(31) 93456-7890"
+    }
+  ],
+  "veiculos": [
+    {
+      "id": 1,
+      "placa": "ROZ-1295",
+      "marca": "Toyota",
+      "modelo": "Corolla",
+      "ano": "2022",
+      "clienteId": 1
+    },
+    {
+      "id": 2,
+      "placa": "PEA-0M40",
+      "marca": "Honda",
+      "modelo": "Civic",
+      "ano": "2021",
+      "clienteId": 3
+    },
+    {
+      "id": 3,
+      "placa": "LBT-3954",
+      "marca": "Ford",
+      "modelo": "Ranger",
+      "ano": "2023",
+      "clienteId": 4
+    },
+    {
+      "id": 4,
+      "placa": "XYZ-7890",
+      "marca": "Chevrolet",
+      "modelo": "Onix",
+      "ano": "2020",
+      "clienteId": 2
+    }
+  ],
+  "pecas": [
+    {
+      "id": 101,
+      "nome": "Filtro de Óleo",
+      "codigo": "FO-001",
+      "estoque": 15,
+      "preco": 35
+    },
+    {
+      "id": 102,
+      "nome": "Pastilha de Freio",
+      "codigo": "PF-002",
+      "estoque": 8,
+      "preco": 120.5
+    },
+    {
+      "id": 103,
+      "nome": "Vela de Ignição",
+      "codigo": "VI-003",
+      "estoque": 32,
+      "preco": 25
+    },
+    {
+      "id": 104,
+      "nome": "Óleo Motor 5W30",
+      "codigo": "OM-004",
+      "estoque": 20,
+      "preco": 55
+    }
+  ],
+  "servicos": [
+    {
+      "id": 201,
+      "descricao": "Troca de Óleo e Filtro",
+      "preco": 150
+    },
+    {
+      "id": 202,
+      "descricao": "Alinhamento e Balanceamento",
+      "preco": 180
+    },
+    {
+      "id": 203,
+      "descricao": "Revisão Sistema de Freios",
+      "preco": 250
+    }
+  ],
+  "ordensServico": [
+    {
+      "id": 974,
+      "clienteId": 1,
+      "veiculoId": 1,
+      "dataEntrada": "2025-09-07",
+      "status": "Em Andamento",
+      "servicos": [
+        {
+          "id": 201,
+          "qtde": 1
+        }
+      ],
+      "pecas": [
+        {
+          "id": 101,
+          "qtde": 1
+        },
+        {
+          "id": 104,
+          "qtde": 1
+        }
+      ]
+    },
+    {
+      "id": 973,
+      "clienteId": 1,
+      "veiculoId": 1,
+      "dataEntrada": "2025-09-06",
+      "status": "Finalizada",
+      "servicos": [
+        {
+          "id": 202,
+          "qtde": 1
+        }
+      ],
+      "pecas": [],
+      "observacoes": "Cliente autorizou serviços adicionais."
+    },
+    {
+      "id": 971,
+      "clienteId": 3,
+      "veiculoId": 2,
+      "dataEntrada": "2025-09-05",
+      "status": "Aguardando Aprovação",
+      "servicos": [
+        {
+          "id": 203,
+          "qtde": 1
+        }
+      ],
+      "pecas": [
+        {
+          "id": 102,
+          "qtde": 2
+        }
+      ]
+    },
+    {
+      "id": 968,
+      "clienteId": 4,
+      "veiculoId": 3,
+      "dataEntrada": "2025-09-02",
+      "status": "Finalizada",
+      "servicos": [
+        {
+          "id": 201,
+          "qtde": 1
+        }
+      ],
+      "pecas": [
+        {
+          "id": 101,
+          "qtde": 1
+        },
+        {
+          "id": 104,
+          "qtde": 1
+        }
+      ],
+      "observacoes": "Veículo entregue ao cliente."
+    }
+  ],
+  "usuarios": [
+    {
+      "id": 1,
+      "nome": "Administrador da Oficina",
+      "email": "admin@oficinapro.com",
+      "senha": "admin123",
+      "perfil": "admin"
+    },
+    {
+      "id": 2,
+      "nome": "Atendimento Principal",
+      "email": "atendimento@oficinapro.com",
+      "senha": "atendimento123",
+      "perfil": "atendimento"
+    }
+  ]
+}

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,325 @@
+const fs = require('fs');
+const path = require('path');
+
+const DB_FILE = path.join(__dirname, 'database.json');
+
+const defaultData = {
+  clientes: [
+    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
+    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
+    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
+    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' }
+  ],
+  veiculos: [
+    { id: 1, placa: 'ROZ-1295', marca: 'Toyota', modelo: 'Corolla', ano: '2022', clienteId: 1 },
+    { id: 2, placa: 'PEA-0M40', marca: 'Honda', modelo: 'Civic', ano: '2021', clienteId: 3 },
+    { id: 3, placa: 'LBT-3954', marca: 'Ford', modelo: 'Ranger', ano: '2023', clienteId: 4 },
+    { id: 4, placa: 'XYZ-7890', marca: 'Chevrolet', modelo: 'Onix', ano: '2020', clienteId: 2 }
+  ],
+  pecas: [
+    { id: 101, nome: 'Filtro de Óleo', codigo: 'FO-001', estoque: 15, preco: 35.0 },
+    { id: 102, nome: 'Pastilha de Freio', codigo: 'PF-002', estoque: 8, preco: 120.5 },
+    { id: 103, nome: 'Vela de Ignição', codigo: 'VI-003', estoque: 32, preco: 25.0 },
+    { id: 104, nome: 'Óleo Motor 5W30', codigo: 'OM-004', estoque: 20, preco: 55.0 }
+  ],
+  servicos: [
+    { id: 201, descricao: 'Troca de Óleo e Filtro', preco: 150.0 },
+    { id: 202, descricao: 'Alinhamento e Balanceamento', preco: 180.0 },
+    { id: 203, descricao: 'Revisão Sistema de Freios', preco: 250.0 }
+  ],
+  ordensServico: [
+    {
+      id: 974,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-07',
+      status: 'Em Andamento',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+      observacoes: undefined
+    },
+    {
+      id: 973,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-06',
+      status: 'Finalizada',
+      servicos: [{ id: 202, qtde: 1 }],
+      pecas: [],
+      observacoes: 'Cliente autorizou serviços adicionais.'
+    },
+    {
+      id: 971,
+      clienteId: 3,
+      veiculoId: 2,
+      dataEntrada: '2025-09-05',
+      status: 'Aguardando Aprovação',
+      servicos: [{ id: 203, qtde: 1 }],
+      pecas: [{ id: 102, qtde: 2 }],
+      observacoes: undefined
+    },
+    {
+      id: 968,
+      clienteId: 4,
+      veiculoId: 3,
+      dataEntrada: '2025-09-02',
+      status: 'Finalizada',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+      observacoes: 'Veículo entregue ao cliente.'
+    }
+  ],
+  usuarios: [
+    {
+      id: 1,
+      nome: 'Administrador da Oficina',
+      email: 'admin@oficinapro.com',
+      senha: 'admin123',
+      perfil: 'admin'
+    },
+    {
+      id: 2,
+      nome: 'Atendimento Principal',
+      email: 'atendimento@oficinapro.com',
+      senha: 'atendimento123',
+      perfil: 'atendimento'
+    }
+  ]
+};
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function loadDatabase() {
+  if (!fs.existsSync(DB_FILE)) {
+    fs.writeFileSync(DB_FILE, JSON.stringify(defaultData, null, 2));
+    return clone(defaultData);
+  }
+
+  try {
+    const raw = fs.readFileSync(DB_FILE, 'utf-8');
+    if (!raw.trim()) {
+      fs.writeFileSync(DB_FILE, JSON.stringify(defaultData, null, 2));
+      return clone(defaultData);
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      clientes: parsed.clientes ?? clone(defaultData.clientes),
+      veiculos: parsed.veiculos ?? clone(defaultData.veiculos),
+      pecas: parsed.pecas ?? clone(defaultData.pecas),
+      servicos: parsed.servicos ?? clone(defaultData.servicos),
+      ordensServico: parsed.ordensServico ?? clone(defaultData.ordensServico),
+      usuarios: parsed.usuarios ?? clone(defaultData.usuarios)
+    };
+  } catch (error) {
+    console.error('Erro ao ler banco de dados, recriando arquivo.', error);
+    fs.writeFileSync(DB_FILE, JSON.stringify(defaultData, null, 2));
+    return clone(defaultData);
+  }
+}
+
+let data = loadDatabase();
+
+function saveDatabase() {
+  fs.writeFileSync(DB_FILE, JSON.stringify(data, null, 2));
+}
+
+function getClientes() {
+  return data.clientes;
+}
+
+function getVeiculos() {
+  return data.veiculos;
+}
+
+function getPecas() {
+  return data.pecas;
+}
+
+function getServicos() {
+  return data.servicos;
+}
+
+function getOrdensServico() {
+  return data.ordensServico;
+}
+
+function getUsuarios() {
+  return data.usuarios;
+}
+
+function nextId(collectionName) {
+  const collection = data[collectionName];
+  const maxId = collection.reduce((max, item) => (item.id > max ? item.id : max), 0);
+  return maxId + 1;
+}
+
+function addCliente(cliente) {
+  const novo = { id: nextId('clientes'), ...cliente };
+  data.clientes = [novo, ...data.clientes];
+  saveDatabase();
+  return novo;
+}
+
+function updateCliente(id, updates) {
+  let atualizado;
+  data.clientes = data.clientes.map(cliente => {
+    if (cliente.id === id) {
+      atualizado = { ...cliente, ...updates, id };
+      return atualizado;
+    }
+    return cliente;
+  });
+  if (atualizado) {
+    saveDatabase();
+  }
+  return atualizado;
+}
+
+function addVeiculo(veiculo) {
+  const novo = { id: nextId('veiculos'), ...veiculo };
+  data.veiculos = [novo, ...data.veiculos];
+  saveDatabase();
+  return novo;
+}
+
+function updateVeiculo(id, updates) {
+  let atualizado;
+  data.veiculos = data.veiculos.map(veiculo => {
+    if (veiculo.id === id) {
+      atualizado = { ...veiculo, ...updates, id };
+      return atualizado;
+    }
+    return veiculo;
+  });
+  if (atualizado) {
+    saveDatabase();
+  }
+  return atualizado;
+}
+
+function addPeca(peca) {
+  const novo = { id: nextId('pecas'), ...peca };
+  data.pecas = [novo, ...data.pecas];
+  saveDatabase();
+  return novo;
+}
+
+function updatePeca(id, updates) {
+  let atualizado;
+  data.pecas = data.pecas.map(peca => {
+    if (peca.id === id) {
+      atualizado = { ...peca, ...updates, id };
+      return atualizado;
+    }
+    return peca;
+  });
+  if (atualizado) {
+    saveDatabase();
+  }
+  return atualizado;
+}
+
+function addOrdemServico(ordem) {
+  const nova = { id: nextId('ordensServico'), servicos: [], pecas: [], ...ordem };
+  data.ordensServico = [nova, ...data.ordensServico];
+  saveDatabase();
+  return nova;
+}
+
+function updateOrdemServico(id, updates) {
+  let atualizada;
+  data.ordensServico = data.ordensServico.map(ordem => {
+    if (ordem.id === id) {
+      atualizada = { ...ordem, ...updates, id };
+      return atualizada;
+    }
+    return ordem;
+  });
+  if (atualizada) {
+    saveDatabase();
+  }
+  return atualizada;
+}
+
+function removeCliente(id) {
+  const existe = data.clientes.some(cliente => cliente.id === id);
+  if (!existe) {
+    return false;
+  }
+  data.clientes = data.clientes.filter(cliente => cliente.id !== id);
+  const veiculosRemovidos = new Set(
+    data.veiculos.filter(veiculo => veiculo.clienteId === id).map(veiculo => veiculo.id)
+  );
+  data.veiculos = data.veiculos.filter(veiculo => veiculo.clienteId !== id);
+  data.ordensServico = data.ordensServico.filter(
+    ordem => ordem.clienteId !== id && !veiculosRemovidos.has(ordem.veiculoId)
+  );
+  saveDatabase();
+  return true;
+}
+
+function removeVeiculo(id) {
+  const existe = data.veiculos.some(veiculo => veiculo.id === id);
+  if (!existe) {
+    return false;
+  }
+  data.veiculos = data.veiculos.filter(veiculo => veiculo.id !== id);
+  data.ordensServico = data.ordensServico.filter(ordem => ordem.veiculoId !== id);
+  saveDatabase();
+  return true;
+}
+
+function removePeca(id) {
+  const existe = data.pecas.some(peca => peca.id === id);
+  if (!existe) {
+    return false;
+  }
+  data.pecas = data.pecas.filter(peca => peca.id !== id);
+  data.ordensServico = data.ordensServico.map(ordem => ({
+    ...ordem,
+    pecas: ordem.pecas.filter(item => item.id !== id)
+  }));
+  saveDatabase();
+  return true;
+}
+
+function removeOrdemServico(id) {
+  const existe = data.ordensServico.some(ordem => ordem.id === id);
+  if (!existe) {
+    return false;
+  }
+  data.ordensServico = data.ordensServico.filter(ordem => ordem.id !== id);
+  saveDatabase();
+  return true;
+}
+
+function findUsuarioPorEmail(email) {
+  return data.usuarios.find(usuario => usuario.email.toLowerCase() === email.toLowerCase());
+}
+
+module.exports = {
+  getClientes,
+  getVeiculos,
+  getPecas,
+  getServicos,
+  getOrdensServico,
+  getUsuarios,
+  addCliente,
+  updateCliente,
+  addVeiculo,
+  updateVeiculo,
+  addPeca,
+  updatePeca,
+  addOrdemServico,
+  updateOrdemServico,
+  removeCliente,
+  removeVeiculo,
+  removePeca,
+  removeOrdemServico,
+  findUsuarioPorEmail,
+  nextId,
+  saveDatabase,
+  data
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,399 @@
+const http = require('http');
+const { URL } = require('url');
+const {
+  getClientes,
+  addCliente,
+  updateCliente,
+  getVeiculos,
+  addVeiculo,
+  updateVeiculo,
+  getPecas,
+  addPeca,
+  updatePeca,
+  getServicos,
+  getOrdensServico,
+  addOrdemServico,
+  updateOrdemServico,
+  removeCliente,
+  removeVeiculo,
+  removePeca,
+  removeOrdemServico,
+  findUsuarioPorEmail
+} = require('./db');
+
+const PORT = process.env.PORT || 3000;
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function sendJson(res, status, data) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(data));
+}
+
+function parseBody(req, res, callback) {
+  const chunks = [];
+  req.on('data', chunk => chunks.push(chunk));
+  req.on('end', () => {
+    if (chunks.length === 0) {
+      callback({});
+      return;
+    }
+
+    try {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+      callback(body);
+    } catch (error) {
+      sendJson(res, 400, { message: 'JSON inválido no corpo da requisição.' });
+    }
+  });
+}
+
+function mapVeiculo(veiculo) {
+  const cliente = getClientes().find(clienteAtual => clienteAtual.id === veiculo.clienteId);
+  return {
+    ...veiculo,
+    clienteNome: cliente ? cliente.nome : 'Cliente não encontrado'
+  };
+}
+
+function mapOrdem(ordem) {
+  return {
+    ...ordem,
+    observacoes: ordem.observacoes || undefined
+  };
+}
+
+function mapUsuario(usuario) {
+  if (!usuario) {
+    return null;
+  }
+  const { senha, ...restante } = usuario;
+  return restante;
+}
+
+const server = http.createServer((req, res) => {
+  if (!req.url) {
+    sendJson(res, 400, { message: 'Requisição inválida.' });
+    return;
+  }
+
+  setCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const pathname = url.pathname;
+
+  try {
+    if (req.method === 'GET' && pathname === '/api/clientes') {
+      const clientes = [...getClientes()].sort((a, b) => b.id - a.id).map(cliente => ({
+        ...cliente,
+        email: cliente.email || undefined,
+        telefone: cliente.telefone || undefined
+      }));
+      sendJson(res, 200, clientes);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/login') {
+      parseBody(req, res, body => {
+        const { email, senha } = body || {};
+        if (!email || !senha) {
+          sendJson(res, 400, { message: 'E-mail e senha são obrigatórios.' });
+          return;
+        }
+
+        const usuario = findUsuarioPorEmail(String(email));
+        if (!usuario || usuario.senha !== senha) {
+          sendJson(res, 401, { message: 'Credenciais inválidas.' });
+          return;
+        }
+
+        const token = Buffer.from(`${usuario.id}:${Date.now()}:${Math.random()}`).toString('base64');
+        sendJson(res, 200, { token, usuario: mapUsuario(usuario) });
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/clientes') {
+      parseBody(req, res, body => {
+        const { nome, email, telefone } = body || {};
+        if (!nome || !nome.trim()) {
+          sendJson(res, 400, { message: 'Nome é obrigatório.' });
+          return;
+        }
+
+        const novo = addCliente({
+          nome: nome.trim(),
+          email: email?.trim() || undefined,
+          telefone: telefone?.trim() || undefined
+        });
+        sendJson(res, 201, novo);
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/clientes\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { nome, email, telefone } = body || {};
+        if (!nome || !nome.trim()) {
+          sendJson(res, 400, { message: 'Nome é obrigatório.' });
+          return;
+        }
+        const atualizado = updateCliente(id, {
+          nome: nome.trim(),
+          email: email?.trim() || undefined,
+          telefone: telefone?.trim() || undefined
+        });
+        if (!atualizado) {
+          sendJson(res, 404, { message: 'Cliente não encontrado.' });
+          return;
+        }
+        sendJson(res, 200, atualizado);
+      });
+      return;
+    }
+
+    if (req.method === 'DELETE' && /^\/api\/clientes\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      const removido = removeCliente(id);
+      if (!removido) {
+        sendJson(res, 404, { message: 'Cliente não encontrado.' });
+        return;
+      }
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/veiculos') {
+      const veiculos = [...getVeiculos()].sort((a, b) => b.id - a.id).map(mapVeiculo);
+      sendJson(res, 200, veiculos);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/veiculos') {
+      parseBody(req, res, body => {
+        const { placa, marca, modelo, ano, clienteId } = body || {};
+        if (!placa || !marca || !modelo || !ano || !clienteId) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const jaExiste = getVeiculos().some(v => v.placa.toLowerCase() === placa.trim().toLowerCase());
+        if (jaExiste) {
+          sendJson(res, 409, { message: 'Já existe um veículo com esta placa.' });
+          return;
+        }
+        const novo = addVeiculo({
+          placa: placa.trim(),
+          marca: marca.trim(),
+          modelo: modelo.trim(),
+          ano: ano.trim(),
+          clienteId: Number(clienteId)
+        });
+        sendJson(res, 201, mapVeiculo(novo));
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/veiculos\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { placa, marca, modelo, ano, clienteId } = body || {};
+        if (!placa || !marca || !modelo || !ano || !clienteId) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const outroVeiculo = getVeiculos().find(v => v.placa.toLowerCase() === placa.trim().toLowerCase() && v.id !== id);
+        if (outroVeiculo) {
+          sendJson(res, 409, { message: 'Já existe um veículo com esta placa.' });
+          return;
+        }
+        const atualizado = updateVeiculo(id, {
+          placa: placa.trim(),
+          marca: marca.trim(),
+          modelo: modelo.trim(),
+          ano: ano.trim(),
+          clienteId: Number(clienteId)
+        });
+        if (!atualizado) {
+          sendJson(res, 404, { message: 'Veículo não encontrado.' });
+          return;
+        }
+        sendJson(res, 200, mapVeiculo(atualizado));
+      });
+      return;
+    }
+
+    if (req.method === 'DELETE' && /^\/api\/veiculos\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      const removido = removeVeiculo(id);
+      if (!removido) {
+        sendJson(res, 404, { message: 'Veículo não encontrado.' });
+        return;
+      }
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/pecas') {
+      const pecas = [...getPecas()].sort((a, b) => b.id - a.id);
+      sendJson(res, 200, pecas);
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/pecas') {
+      parseBody(req, res, body => {
+        const { nome, codigo, estoque, preco } = body || {};
+        if (!nome || !codigo) {
+          sendJson(res, 400, { message: 'Nome e código são obrigatórios.' });
+          return;
+        }
+        const novo = addPeca({
+          nome: nome.trim(),
+          codigo: codigo.trim(),
+          estoque: Number.isFinite(Number(estoque)) ? Number(estoque) : 0,
+          preco: Number.isFinite(Number(preco)) ? Number(preco) : 0
+        });
+        sendJson(res, 201, novo);
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/pecas\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { nome, codigo, estoque, preco } = body || {};
+        if (!nome || !codigo) {
+          sendJson(res, 400, { message: 'Nome e código são obrigatórios.' });
+          return;
+        }
+        const atualizada = updatePeca(id, {
+          nome: nome.trim(),
+          codigo: codigo.trim(),
+          estoque: Number.isFinite(Number(estoque)) ? Number(estoque) : 0,
+          preco: Number.isFinite(Number(preco)) ? Number(preco) : 0
+        });
+        if (!atualizada) {
+          sendJson(res, 404, { message: 'Peça não encontrada.' });
+          return;
+        }
+        sendJson(res, 200, atualizada);
+      });
+      return;
+    }
+
+    if (req.method === 'DELETE' && /^\/api\/pecas\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      const removida = removePeca(id);
+      if (!removida) {
+        sendJson(res, 404, { message: 'Peça não encontrada.' });
+        return;
+      }
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/servicos') {
+      const servicos = [...getServicos()].sort((a, b) => b.id - a.id);
+      sendJson(res, 200, servicos);
+      return;
+    }
+
+    if (req.method === 'GET' && pathname === '/api/ordens-servico') {
+      const ordens = [...getOrdensServico()].sort((a, b) => b.id - a.id).map(mapOrdem);
+      sendJson(res, 200, ordens);
+      return;
+    }
+
+    if (req.method === 'GET' && /^\/api\/ordens-servico\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      const ordem = getOrdensServico().find(item => item.id === id);
+      if (!ordem) {
+        sendJson(res, 404, { message: 'Ordem de serviço não encontrada.' });
+        return;
+      }
+      sendJson(res, 200, mapOrdem(ordem));
+      return;
+    }
+
+    if (req.method === 'POST' && pathname === '/api/ordens-servico') {
+      parseBody(req, res, body => {
+        const { clienteId, veiculoId, dataEntrada, status, servicos = [], pecas = [], observacoes } = body || {};
+        if (!clienteId || !veiculoId || !dataEntrada || !status) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const nova = addOrdemServico({
+          clienteId: Number(clienteId),
+          veiculoId: Number(veiculoId),
+          dataEntrada,
+          status,
+          servicos: Array.isArray(servicos) ? servicos : [],
+          pecas: Array.isArray(pecas) ? pecas : [],
+          observacoes: observacoes?.trim() || undefined
+        });
+        sendJson(res, 201, mapOrdem(nova));
+      });
+      return;
+    }
+
+    if (req.method === 'PUT' && /^\/api\/ordens-servico\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      parseBody(req, res, body => {
+        const { clienteId, veiculoId, dataEntrada, status, servicos = [], pecas = [], observacoes } = body || {};
+        if (!clienteId || !veiculoId || !dataEntrada || !status) {
+          sendJson(res, 400, { message: 'Dados obrigatórios ausentes.' });
+          return;
+        }
+        const atualizada = updateOrdemServico(id, {
+          clienteId: Number(clienteId),
+          veiculoId: Number(veiculoId),
+          dataEntrada,
+          status,
+          servicos: Array.isArray(servicos) ? servicos : [],
+          pecas: Array.isArray(pecas) ? pecas : [],
+          observacoes: observacoes?.trim() || undefined
+        });
+        if (!atualizada) {
+          sendJson(res, 404, { message: 'Ordem de serviço não encontrada.' });
+          return;
+        }
+        sendJson(res, 200, mapOrdem(atualizada));
+      });
+      return;
+    }
+
+    if (req.method === 'DELETE' && /^\/api\/ordens-servico\/\d+$/.test(pathname)) {
+      const id = Number(pathname.split('/').pop());
+      const removida = removeOrdemServico(id);
+      if (!removida) {
+        sendJson(res, 404, { message: 'Ordem de serviço não encontrada.' });
+        return;
+      }
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    sendJson(res, 404, { message: 'Rota não encontrada.' });
+  } catch (error) {
+    console.error('Erro inesperado:', error);
+    sendJson(res, 500, { message: 'Erro interno do servidor.' });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Servidor da API iniciado em http://localhost:${PORT}`);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -93,6 +93,11 @@ const server = http.createServer((req, res) => {
   const pathname = url.pathname;
 
   try {
+    if (req.method === 'GET' && pathname === '/api/status') {
+      sendJson(res, 200, { status: 'ok' });
+      return;
+    }
+
     if (req.method === 'GET' && pathname === '/api/clientes') {
       const clientes = [...getClientes()].sort((a, b) => b.id - a.id).map(cliente => ({
         ...cliente,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,8 @@
 import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes)]
+  providers: [provideRouter(routes), provideHttpClient()]
 };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -28,11 +28,11 @@
             (click)="toggleProfileMenu()"
           >
             <div class="mr-2 h-9 w-9 rounded-full bg-gradient-to-br from-sky-500 via-blue-500 to-indigo-600 text-white flex items-center justify-center font-semibold shadow-lg shadow-sky-500/40">
-              A
+              {{ iniciaisUsuario() }}
             </div>
             <div class="hidden sm:block leading-tight">
-              <p class="font-semibold text-slate-100">Admin</p>
-              <p class="text-xs text-slate-300/80">Administrador</p>
+              <p class="font-semibold text-slate-100">{{ usuarioAtual()?.nome || 'Usuário' }}</p>
+              <p class="text-xs text-slate-300/80 capitalize">{{ usuarioAtual()?.perfil || 'sem perfil' }}</p>
             </div>
             <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 h-4 w-4 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9 6 6 6-6" /></svg>
           </button>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,15 +6,16 @@ import { ResumoOsComponent } from './pages/resumo-os.component';
 import { VeiculosComponent } from './pages/veiculos.component';
 import { LoginComponent } from './pages/login.component';
 import { ClientesComponent } from './pages/clientes.component';
+import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
     { path: 'login', component: LoginComponent },
-    { path: 'inicio', component: DashboardComponent },
-    { path: 'ordens-servico', component: OrdensServicoComponent },
-    { path: 'ordens-servico/:id', component: ResumoOsComponent },
-    { path: 'veiculos', component: VeiculosComponent },
-    { path: 'estoque', component: EstoqueComponent },
-    { path: 'clientes', component: ClientesComponent },
+    { path: 'inicio', component: DashboardComponent, canActivate: [authGuard] },
+    { path: 'ordens-servico', component: OrdensServicoComponent, canActivate: [authGuard] },
+    { path: 'ordens-servico/:id', component: ResumoOsComponent, canActivate: [authGuard] },
+    { path: 'veiculos', component: VeiculosComponent, canActivate: [authGuard] },
+    { path: 'estoque', component: EstoqueComponent, canActivate: [authGuard] },
+    { path: 'clientes', component: ClientesComponent, canActivate: [authGuard] },
 
     { path: '', redirectTo: '/login', pathMatch: 'full' }, // Redireciona a raiz para a tela de login
     { path: '**', redirectTo: '/login' } // Rota curinga para qualquer URL inválida

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,6 +4,7 @@ import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './layout/sidebar.component';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter, map, startWith } from 'rxjs';
+import { AuthService } from './core/services/auth.service';
 
 @Component({
   selector: 'app-root',
@@ -14,6 +15,7 @@ import { filter, map, startWith } from 'rxjs';
 })
 export class App {
   private router = inject(Router);
+  private authService = inject(AuthService);
 
   isMobileMenuOpen = signal(false);
   private profileMenuOpen = signal(false);
@@ -29,6 +31,20 @@ export class App {
 
   isLoginRoute = computed(() => this.currentUrl().startsWith('/login'));
   isProfileMenuOpen = computed(() => this.profileMenuOpen());
+  usuarioAtual = this.authService.usuarioAtual;
+  estaAutenticado = this.authService.estaAutenticado;
+  iniciaisUsuario = computed(() => {
+    const usuario = this.usuarioAtual();
+    if (!usuario) {
+      return 'US';
+    }
+    return usuario.nome
+      .split(' ')
+      .filter(Boolean)
+      .slice(0, 2)
+      .map(parte => parte[0]?.toUpperCase() ?? '')
+      .join('') || 'US';
+  });
 
   toggleProfileMenu(): void {
     this.profileMenuOpen.update(value => !value);
@@ -37,6 +53,7 @@ export class App {
   logout(): void {
     this.profileMenuOpen.set(false);
     this.isMobileMenuOpen.set(false);
+    this.authService.logout();
     void this.router.navigate(['/login']);
   }
 }

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = (_route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.estaAutenticado()) {
+    return true;
+  }
+
+  void router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
+  return false;
+};

--- a/src/app/core/models/models.ts
+++ b/src/app/core/models/models.ts
@@ -48,3 +48,12 @@ export interface MenuItem {
   path: string;
   iconPath: string;
 }
+
+export type PerfilUsuario = 'admin' | 'atendimento' | 'mecanico';
+
+export interface Usuario {
+  id: number;
+  nome: string;
+  email: string;
+  perfil: PerfilUsuario;
+}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { PerfilUsuario, Usuario } from '../models/models';
+
+type LoginPayload = { email: string; senha: string };
+
+type LoginResponse = {
+  token: string;
+  usuario: Usuario;
+};
+
+type UsuarioAutenticavel = Usuario & { senha: string };
+
+const OFFLINE_USUARIOS: UsuarioAutenticavel[] = [
+  {
+    id: 1,
+    nome: 'Administrador da Oficina',
+    email: 'admin@oficinapro.com',
+    perfil: 'admin',
+    senha: 'admin123'
+  },
+  {
+    id: 2,
+    nome: 'Atendimento Principal',
+    email: 'atendimento@oficinapro.com',
+    perfil: 'atendimento',
+    senha: 'atendimento123'
+  }
+];
+
+interface SessaoPersistida {
+  token: string;
+  usuario: Usuario;
+  expiraEm: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+  private readonly apiUrl = 'http://localhost:3000/api';
+  private readonly storageKey = 'planu-center/auth';
+
+  private readonly usuarioInterno = signal<Usuario | null>(this.restaurarSessao());
+  readonly usuarioAtual = computed(() => this.usuarioInterno());
+  readonly estaAutenticado = computed(() => !!this.usuarioInterno());
+
+  async login(email: string, senha: string) {
+    const payload: LoginPayload = { email: email.trim().toLowerCase(), senha };
+
+    try {
+      const resposta = await firstValueFrom(
+        this.http.post<LoginResponse>(`${this.apiUrl}/login`, payload)
+      );
+      this.persistirSessao(resposta);
+      return resposta.usuario;
+    } catch (error: any) {
+      const deveTentarOffline = !error?.status || error.status >= 500;
+      if (!deveTentarOffline) {
+        throw error;
+      }
+
+      const usuarioOffline = this.autenticarOffline(payload.email, payload.senha);
+      if (!usuarioOffline) {
+        throw error;
+      }
+
+      const respostaOffline: LoginResponse = {
+        token: this.gerarTokenOffline(usuarioOffline),
+        usuario: this.mapearUsuario(usuarioOffline)
+      };
+      this.persistirSessao(respostaOffline, true);
+      return respostaOffline.usuario;
+    }
+  }
+
+  logout() {
+    this.usuarioInterno.set(null);
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(this.storageKey);
+    }
+  }
+
+  atualizarPerfilUsuario(nome: string, perfil: PerfilUsuario) {
+    const usuario = this.usuarioInterno();
+    if (!usuario) {
+      return;
+    }
+    const atualizado: Usuario = { ...usuario, nome, perfil };
+    this.usuarioInterno.set(atualizado);
+    if (typeof localStorage !== 'undefined') {
+      const armazenado = this.obterSessaoPersistida();
+      if (armazenado) {
+        localStorage.setItem(
+          this.storageKey,
+          JSON.stringify({ ...armazenado, usuario: atualizado })
+        );
+      }
+    }
+  }
+
+  private mapearUsuario(usuario: UsuarioAutenticavel): Usuario {
+    const { senha: _senha, ...resto } = usuario;
+    return resto;
+  }
+
+  private autenticarOffline(email: string, senha: string) {
+    return OFFLINE_USUARIOS.find(
+      usuario => usuario.email.toLowerCase() === email && usuario.senha === senha
+    );
+  }
+
+  private gerarTokenOffline(usuario: UsuarioAutenticavel) {
+    return btoa(`${usuario.id}:${Date.now()}`);
+  }
+
+  private persistirSessao(resposta: LoginResponse, offline = false) {
+    this.usuarioInterno.set(resposta.usuario);
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+
+    const expiraEm = Date.now() + (offline ? 8 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000);
+    const dados: SessaoPersistida = {
+      token: resposta.token,
+      usuario: resposta.usuario,
+      expiraEm
+    };
+    localStorage.setItem(this.storageKey, JSON.stringify(dados));
+  }
+
+  private restaurarSessao(): Usuario | null {
+    const dados = this.obterSessaoPersistida();
+    if (!dados) {
+      return null;
+    }
+    if (Date.now() > dados.expiraEm) {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(this.storageKey);
+      }
+      return null;
+    }
+    return dados.usuario;
+  }
+
+  private obterSessaoPersistida(): SessaoPersistida | null {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    const bruto = localStorage.getItem(this.storageKey);
+    if (!bruto) {
+      return null;
+    }
+    try {
+      return JSON.parse(bruto) as SessaoPersistida;
+    } catch (error) {
+      localStorage.removeItem(this.storageKey);
+      return null;
+    }
+  }
+}

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -89,6 +89,8 @@ export class DataService {
   private readonly apiUrl = 'http://localhost:3000/api';
   private readonly offlineState: OfflineDatabase = deepClone(OFFLINE_DATA);
   private notificouFalhaApi = false;
+  private apiDisponivel = true;
+  private verificandoApi?: Promise<boolean>;
 
   readonly clientes = signal<Cliente[]>([]);
   readonly veiculos = signal<Veiculo[]>([]);
@@ -116,6 +118,9 @@ export class DataService {
       this.reaplicarClientesOffline();
       return;
     }
+    if (!(await this.garantirApiDisponivel('clientes'))) {
+      return;
+    }
     try {
       const clientes = await firstValueFrom(this.http.get<Cliente[]>(`${this.apiUrl}/clientes`));
       this.atualizarClientes(clientes);
@@ -127,6 +132,10 @@ export class DataService {
 
   async criarCliente(dados: Omit<Cliente, 'id'>) {
     if (this.modoOffline()) {
+      return this.criarClienteOffline(dados);
+    }
+
+    if (!(await this.garantirApiDisponivel('clientes'))) {
       return this.criarClienteOffline(dados);
     }
 
@@ -147,6 +156,10 @@ export class DataService {
       return this.atualizarClienteOffline(id, dados);
     }
 
+    if (!(await this.garantirApiDisponivel('clientes'))) {
+      return this.atualizarClienteOffline(id, dados);
+    }
+
     try {
       const atualizado = await firstValueFrom(this.http.put<Cliente>(`${this.apiUrl}/clientes/${id}`, dados));
       this.clientes.update(lista => lista.map(cliente => (cliente.id === id ? atualizado : cliente)));
@@ -162,6 +175,11 @@ export class DataService {
 
   async removerCliente(id: number) {
     if (this.modoOffline()) {
+      this.removerClienteOffline(id);
+      return;
+    }
+
+    if (!(await this.garantirApiDisponivel('clientes'))) {
       this.removerClienteOffline(id);
       return;
     }
@@ -186,6 +204,9 @@ export class DataService {
       this.reaplicarVeiculosOffline();
       return;
     }
+    if (!(await this.garantirApiDisponivel('veículos'))) {
+      return;
+    }
     try {
       const veiculos = await firstValueFrom(this.http.get<Veiculo[]>(`${this.apiUrl}/veiculos`));
       this.atualizarVeiculos(veiculos);
@@ -197,6 +218,10 @@ export class DataService {
 
   async criarVeiculo(dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
     if (this.modoOffline()) {
+      return this.criarVeiculoOffline(dados);
+    }
+
+    if (!(await this.garantirApiDisponivel('veículos'))) {
       return this.criarVeiculoOffline(dados);
     }
 
@@ -217,6 +242,10 @@ export class DataService {
       return this.atualizarVeiculoOffline(id, dados);
     }
 
+    if (!(await this.garantirApiDisponivel('veículos'))) {
+      return this.atualizarVeiculoOffline(id, dados);
+    }
+
     try {
       const atualizado = await firstValueFrom(this.http.put<Veiculo>(`${this.apiUrl}/veiculos/${id}`, dados));
       this.veiculos.update(lista => lista.map(veiculo => (veiculo.id === id ? atualizado : veiculo)));
@@ -231,6 +260,11 @@ export class DataService {
 
   async removerVeiculo(id: number) {
     if (this.modoOffline()) {
+      this.removerVeiculoOffline(id);
+      return;
+    }
+
+    if (!(await this.garantirApiDisponivel('veículos'))) {
       this.removerVeiculoOffline(id);
       return;
     }
@@ -253,6 +287,9 @@ export class DataService {
       this.reaplicarPecasOffline();
       return;
     }
+    if (!(await this.garantirApiDisponivel('peças'))) {
+      return;
+    }
     try {
       const pecas = await firstValueFrom(this.http.get<Peca[]>(`${this.apiUrl}/pecas`));
       this.atualizarPecas(pecas);
@@ -264,6 +301,10 @@ export class DataService {
 
   async criarPeca(dados: Omit<Peca, 'id'>) {
     if (this.modoOffline()) {
+      return this.criarPecaOffline(dados);
+    }
+
+    if (!(await this.garantirApiDisponivel('peças'))) {
       return this.criarPecaOffline(dados);
     }
 
@@ -284,6 +325,10 @@ export class DataService {
       return this.atualizarPecaOffline(id, dados);
     }
 
+    if (!(await this.garantirApiDisponivel('peças'))) {
+      return this.atualizarPecaOffline(id, dados);
+    }
+
     try {
       const atualizada = await firstValueFrom(this.http.put<Peca>(`${this.apiUrl}/pecas/${id}`, dados));
       this.pecas.update(lista => lista.map(peca => (peca.id === id ? atualizada : peca)));
@@ -298,6 +343,11 @@ export class DataService {
 
   async removerPeca(id: number) {
     if (this.modoOffline()) {
+      this.removerPecaOffline(id);
+      return;
+    }
+
+    if (!(await this.garantirApiDisponivel('peças'))) {
       this.removerPecaOffline(id);
       return;
     }
@@ -325,6 +375,9 @@ export class DataService {
       this.reaplicarServicosOffline();
       return;
     }
+    if (!(await this.garantirApiDisponivel('serviços'))) {
+      return;
+    }
     try {
       const servicos = await firstValueFrom(this.http.get<Servico[]>(`${this.apiUrl}/servicos`));
       this.atualizarServicos(servicos);
@@ -339,6 +392,9 @@ export class DataService {
       this.reaplicarOrdensOffline();
       return;
     }
+    if (!(await this.garantirApiDisponivel('ordens de serviço'))) {
+      return;
+    }
     try {
       const ordens = await firstValueFrom(this.http.get<OrdemServico[]>(`${this.apiUrl}/ordens-servico`));
       this.atualizarOrdens(ordens);
@@ -350,6 +406,10 @@ export class DataService {
 
   async criarOrdemServico(dados: Omit<OrdemServico, 'id'>) {
     if (this.modoOffline()) {
+      return this.criarOrdemOffline(dados);
+    }
+
+    if (!(await this.garantirApiDisponivel('ordens de serviço'))) {
       return this.criarOrdemOffline(dados);
     }
 
@@ -367,6 +427,10 @@ export class DataService {
 
   async atualizarOrdemServico(id: number, dados: Omit<OrdemServico, 'id'>) {
     if (this.modoOffline()) {
+      return this.atualizarOrdemOffline(id, dados);
+    }
+
+    if (!(await this.garantirApiDisponivel('ordens de serviço'))) {
       return this.atualizarOrdemOffline(id, dados);
     }
 
@@ -388,6 +452,11 @@ export class DataService {
       return;
     }
 
+    if (!(await this.garantirApiDisponivel('ordens de serviço'))) {
+      this.removerOrdemOffline(id);
+      return;
+    }
+
     try {
       await firstValueFrom(this.http.delete<void>(`${this.apiUrl}/ordens-servico/${id}`));
       this.ordensServico.update(lista => lista.filter(ordem => ordem.id !== id));
@@ -401,6 +470,36 @@ export class DataService {
 
   getOrdemServicoById(id: number): OrdemServico | undefined {
     return this.ordensServico().find(os => os.id === id);
+  }
+
+  private async garantirApiDisponivel(contexto: string) {
+    if (this.modoOffline() || !this.apiDisponivel) {
+      return false;
+    }
+
+    if (!this.verificandoApi) {
+      this.verificandoApi = this.pingApi().then(disponivel => {
+        this.apiDisponivel = disponivel;
+        if (!disponivel) {
+          this.registrarFalhaApi(contexto);
+          this.ativarModoOffline();
+        }
+        return disponivel;
+      }).finally(() => {
+        this.verificandoApi = undefined;
+      });
+    }
+
+    return this.verificandoApi;
+  }
+
+  private async pingApi(): Promise<boolean> {
+    try {
+      const resposta = await fetch(`${this.apiUrl}/status`, { method: 'GET', cache: 'no-store' });
+      return resposta.ok;
+    } catch {
+      return false;
+    }
   }
 
   private registrarFalhaApi(contexto: string) {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -100,10 +100,26 @@ export class DataService {
   readonly modoOffline = signal(false);
 
   constructor() {
+    this.aplicarInstantaneoOffline();
     void this.carregarDadosIniciais();
   }
 
+  private aplicarInstantaneoOffline() {
+    this.reaplicarClientesOffline();
+    this.reaplicarVeiculosOffline();
+    this.reaplicarPecasOffline();
+    this.reaplicarServicosOffline();
+    this.reaplicarOrdensOffline();
+  }
+
   async carregarDadosIniciais() {
+    const sincronizacaoDisponivel = await this.garantirApiDisponivel('sincronização inicial');
+    if (!sincronizacaoDisponivel) {
+      return;
+    }
+
+    this.modoOffline.set(false);
+
     await Promise.all([
       this.carregarClientes(),
       this.carregarVeiculos(),
@@ -518,11 +534,7 @@ export class DataService {
     if (!this.notificouFalhaApi) {
       console.warn('API indisponível. Entrando em modo offline com dados locais.');
     }
-    this.reaplicarClientesOffline();
-    this.reaplicarVeiculosOffline();
-    this.reaplicarPecasOffline();
-    this.reaplicarServicosOffline();
-    this.reaplicarOrdensOffline();
+    this.aplicarInstantaneoOffline();
   }
 
   private gerarProximoId(lista: { id: number }[]) {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -88,6 +88,7 @@ export class DataService {
   private http = inject(HttpClient);
   private readonly apiUrl = 'http://localhost:3000/api';
   private readonly offlineState: OfflineDatabase = deepClone(OFFLINE_DATA);
+  private notificouFalhaApi = false;
 
   readonly clientes = signal<Cliente[]>([]);
   readonly veiculos = signal<Veiculo[]>([]);
@@ -119,7 +120,7 @@ export class DataService {
       const clientes = await firstValueFrom(this.http.get<Cliente[]>(`${this.apiUrl}/clientes`));
       this.atualizarClientes(clientes);
     } catch (error) {
-      console.error('Erro ao carregar clientes', error);
+      this.registrarFalhaApi('clientes');
       this.ativarModoOffline();
     }
   }
@@ -135,7 +136,7 @@ export class DataService {
       this.offlineState.clientes = deepClone(this.clientes());
       return novo;
     } catch (error) {
-      console.error('Erro ao criar cliente', error);
+      this.registrarFalhaApi('clientes');
       this.ativarModoOffline();
       return this.criarClienteOffline(dados);
     }
@@ -153,7 +154,7 @@ export class DataService {
       await this.carregarVeiculos();
       return atualizado;
     } catch (error) {
-      console.error('Erro ao atualizar cliente', error);
+      this.registrarFalhaApi('clientes');
       this.ativarModoOffline();
       return this.atualizarClienteOffline(id, dados);
     }
@@ -174,7 +175,7 @@ export class DataService {
       this.offlineState.veiculos = deepClone(this.veiculos());
       this.offlineState.ordensServico = deepClone(this.ordensServico());
     } catch (error) {
-      console.error('Erro ao remover cliente', error);
+      this.registrarFalhaApi('clientes');
       this.ativarModoOffline();
       this.removerClienteOffline(id);
     }
@@ -189,7 +190,7 @@ export class DataService {
       const veiculos = await firstValueFrom(this.http.get<Veiculo[]>(`${this.apiUrl}/veiculos`));
       this.atualizarVeiculos(veiculos);
     } catch (error) {
-      console.error('Erro ao carregar veículos', error);
+      this.registrarFalhaApi('veículos');
       this.ativarModoOffline();
     }
   }
@@ -205,7 +206,7 @@ export class DataService {
       this.offlineState.veiculos = deepClone(this.veiculos());
       return novo;
     } catch (error) {
-      console.error('Erro ao criar veículo', error);
+      this.registrarFalhaApi('veículos');
       this.ativarModoOffline();
       return this.criarVeiculoOffline(dados);
     }
@@ -222,7 +223,7 @@ export class DataService {
       this.offlineState.veiculos = deepClone(this.veiculos());
       return atualizado;
     } catch (error) {
-      console.error('Erro ao atualizar veículo', error);
+      this.registrarFalhaApi('veículos');
       this.ativarModoOffline();
       return this.atualizarVeiculoOffline(id, dados);
     }
@@ -241,7 +242,7 @@ export class DataService {
       this.offlineState.veiculos = deepClone(this.veiculos());
       this.offlineState.ordensServico = deepClone(this.ordensServico());
     } catch (error) {
-      console.error('Erro ao remover veículo', error);
+      this.registrarFalhaApi('veículos');
       this.ativarModoOffline();
       this.removerVeiculoOffline(id);
     }
@@ -256,7 +257,7 @@ export class DataService {
       const pecas = await firstValueFrom(this.http.get<Peca[]>(`${this.apiUrl}/pecas`));
       this.atualizarPecas(pecas);
     } catch (error) {
-      console.error('Erro ao carregar peças', error);
+      this.registrarFalhaApi('peças');
       this.ativarModoOffline();
     }
   }
@@ -272,7 +273,7 @@ export class DataService {
       this.offlineState.pecas = deepClone(this.pecas());
       return nova;
     } catch (error) {
-      console.error('Erro ao criar peça', error);
+      this.registrarFalhaApi('peças');
       this.ativarModoOffline();
       return this.criarPecaOffline(dados);
     }
@@ -289,7 +290,7 @@ export class DataService {
       this.offlineState.pecas = deepClone(this.pecas());
       return atualizada;
     } catch (error) {
-      console.error('Erro ao atualizar peça', error);
+      this.registrarFalhaApi('peças');
       this.ativarModoOffline();
       return this.atualizarPecaOffline(id, dados);
     }
@@ -313,7 +314,7 @@ export class DataService {
       this.offlineState.pecas = deepClone(this.pecas());
       this.offlineState.ordensServico = deepClone(this.ordensServico());
     } catch (error) {
-      console.error('Erro ao remover peça', error);
+      this.registrarFalhaApi('peças');
       this.ativarModoOffline();
       this.removerPecaOffline(id);
     }
@@ -328,7 +329,7 @@ export class DataService {
       const servicos = await firstValueFrom(this.http.get<Servico[]>(`${this.apiUrl}/servicos`));
       this.atualizarServicos(servicos);
     } catch (error) {
-      console.error('Erro ao carregar serviços', error);
+      this.registrarFalhaApi('serviços');
       this.ativarModoOffline();
     }
   }
@@ -342,7 +343,7 @@ export class DataService {
       const ordens = await firstValueFrom(this.http.get<OrdemServico[]>(`${this.apiUrl}/ordens-servico`));
       this.atualizarOrdens(ordens);
     } catch (error) {
-      console.error('Erro ao carregar ordens de serviço', error);
+      this.registrarFalhaApi('ordens de serviço');
       this.ativarModoOffline();
     }
   }
@@ -358,7 +359,7 @@ export class DataService {
       this.offlineState.ordensServico = deepClone(this.ordensServico());
       return nova;
     } catch (error) {
-      console.error('Erro ao criar ordem de serviço', error);
+      this.registrarFalhaApi('ordens de serviço');
       this.ativarModoOffline();
       return this.criarOrdemOffline(dados);
     }
@@ -375,7 +376,7 @@ export class DataService {
       this.offlineState.ordensServico = deepClone(this.ordensServico());
       return atualizada;
     } catch (error) {
-      console.error('Erro ao atualizar ordem de serviço', error);
+      this.registrarFalhaApi('ordens de serviço');
       this.ativarModoOffline();
       return this.atualizarOrdemOffline(id, dados);
     }
@@ -392,7 +393,7 @@ export class DataService {
       this.ordensServico.update(lista => lista.filter(ordem => ordem.id !== id));
       this.offlineState.ordensServico = deepClone(this.ordensServico());
     } catch (error) {
-      console.error('Erro ao remover ordem de serviço', error);
+      this.registrarFalhaApi('ordens de serviço');
       this.ativarModoOffline();
       this.removerOrdemOffline(id);
     }
@@ -402,12 +403,22 @@ export class DataService {
     return this.ordensServico().find(os => os.id === id);
   }
 
+  private registrarFalhaApi(contexto: string) {
+    if (this.notificouFalhaApi) {
+      return;
+    }
+    this.notificouFalhaApi = true;
+    console.warn(`Não foi possível conectar à API (${contexto}). Os dados locais serão utilizados.`);
+  }
+
   private ativarModoOffline() {
     if (this.modoOffline()) {
       return;
     }
     this.modoOffline.set(true);
-    console.warn('API indisponível. Entrando em modo offline com dados locais.');
+    if (!this.notificouFalhaApi) {
+      console.warn('API indisponível. Entrando em modo offline com dados locais.');
+    }
     this.reaplicarClientesOffline();
     this.reaplicarVeiculosOffline();
     this.reaplicarPecasOffline();

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,83 +1,638 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { Cliente, OrdemServico, Peca, Servico, Veiculo } from '../models/models';
+
+type OfflineDatabase = {
+  clientes: Cliente[];
+  veiculos: Veiculo[];
+  pecas: Peca[];
+  servicos: Servico[];
+  ordensServico: OrdemServico[];
+};
+
+const OFFLINE_DATA: OfflineDatabase = {
+  clientes: [
+    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
+    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
+    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
+    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' }
+  ],
+  veiculos: [
+    { id: 1, placa: 'ROZ-1295', marca: 'Toyota', modelo: 'Corolla', ano: '2022', clienteId: 1, clienteNome: 'Carlos Alberto' },
+    { id: 2, placa: 'PEA-0M40', marca: 'Honda', modelo: 'Civic', ano: '2021', clienteId: 3, clienteNome: 'Pedro Henrique' },
+    { id: 3, placa: 'LBT-3954', marca: 'Ford', modelo: 'Ranger', ano: '2023', clienteId: 4, clienteNome: 'João da Silva' },
+    { id: 4, placa: 'XYZ-7890', marca: 'Chevrolet', modelo: 'Onix', ano: '2020', clienteId: 2, clienteNome: 'Joana Pereira' }
+  ],
+  pecas: [
+    { id: 101, nome: 'Filtro de Óleo', codigo: 'FO-001', estoque: 15, preco: 35 },
+    { id: 102, nome: 'Pastilha de Freio', codigo: 'PF-002', estoque: 8, preco: 120.5 },
+    { id: 103, nome: 'Vela de Ignição', codigo: 'VI-003', estoque: 32, preco: 25 },
+    { id: 104, nome: 'Óleo Motor 5W30', codigo: 'OM-004', estoque: 20, preco: 55 }
+  ],
+  servicos: [
+    { id: 201, descricao: 'Troca de Óleo e Filtro', preco: 150 },
+    { id: 202, descricao: 'Alinhamento e Balanceamento', preco: 180 },
+    { id: 203, descricao: 'Revisão Sistema de Freios', preco: 250 }
+  ],
+  ordensServico: [
+    {
+      id: 974,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-07',
+      status: 'Em Andamento',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }]
+    },
+    {
+      id: 973,
+      clienteId: 1,
+      veiculoId: 1,
+      dataEntrada: '2025-09-06',
+      status: 'Finalizada',
+      servicos: [{ id: 202, qtde: 1 }],
+      pecas: [],
+      observacoes: 'Cliente autorizou serviços adicionais.'
+    },
+    {
+      id: 971,
+      clienteId: 3,
+      veiculoId: 2,
+      dataEntrada: '2025-09-05',
+      status: 'Aguardando Aprovação',
+      servicos: [{ id: 203, qtde: 1 }],
+      pecas: [{ id: 102, qtde: 2 }]
+    },
+    {
+      id: 968,
+      clienteId: 4,
+      veiculoId: 3,
+      dataEntrada: '2025-09-02',
+      status: 'Finalizada',
+      servicos: [{ id: 201, qtde: 1 }],
+      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
+      observacoes: 'Veículo entregue ao cliente.'
+    }
+  ]
+};
+
+const deepClone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const sortByIdDesc = <T extends { id: number }>(lista: T[]): T[] => [...lista].sort((a, b) => b.id - a.id);
 
 @Injectable({
   providedIn: 'root'
 })
 export class DataService {
+  private http = inject(HttpClient);
+  private readonly apiUrl = 'http://localhost:3000/api';
+  private readonly offlineState: OfflineDatabase = deepClone(OFFLINE_DATA);
 
-  // --- DADOS MOCKADOS (Simulação de um banco de dados) ---
-  // Usando Signals para reatividade.
-  
-  readonly clientes = signal<Cliente[]>([
-    { id: 1, nome: 'Carlos Alberto', email: 'carlos.alberto@email.com', telefone: '(11) 91234-5678' },
-    { id: 2, nome: 'Joana Pereira', email: 'joana.pereira@email.com', telefone: '(11) 98765-4321' },
-    { id: 3, nome: 'Pedro Henrique', email: 'pedro.henrique@email.com', telefone: '(21) 99876-5432' },
-    { id: 4, nome: 'João da Silva', email: 'joao.silva@email.com', telefone: '(31) 93456-7890' },
-  ]);
+  readonly clientes = signal<Cliente[]>([]);
+  readonly veiculos = signal<Veiculo[]>([]);
+  readonly pecas = signal<Peca[]>([]);
+  readonly servicos = signal<Servico[]>([]);
+  readonly ordensServico = signal<OrdemServico[]>([]);
+  readonly modoOffline = signal(false);
 
-  readonly veiculos = signal<Veiculo[]>([
-    { id: 1, placa: 'ROZ-1295', marca: 'Toyota', modelo: 'Corolla', ano: '2022', clienteId: 1, clienteNome: 'Carlos Alberto' },
-    { id: 2, placa: 'PEA-0M40', marca: 'Honda', modelo: 'Civic', ano: '2021', clienteId: 3, clienteNome: 'Pedro Henrique' },
-    { id: 3, placa: 'LBT-3954', marca: 'Ford', modelo: 'Ranger', ano: '2023', clienteId: 4, clienteNome: 'João da Silva' },
-    { id: 4, placa: 'XYZ-7890', marca: 'Chevrolet', modelo: 'Onix', ano: '2020', clienteId: 2, clienteNome: 'Joana Pereira' },
-  ]);
+  constructor() {
+    void this.carregarDadosIniciais();
+  }
 
-  readonly pecas = signal<Peca[]>([
-    { id: 101, nome: 'Filtro de Óleo', codigo: 'FO-001', estoque: 15, preco: 35.00 },
-    { id: 102, nome: 'Pastilha de Freio', codigo: 'PF-002', estoque: 8, preco: 120.50 },
-    { id: 103, nome: 'Vela de Ignição', codigo: 'VI-003', estoque: 32, preco: 25.00 },
-    { id: 104, nome: 'Óleo Motor 5W30', codigo: 'OM-004', estoque: 20, preco: 55.00 },
-  ]);
+  async carregarDadosIniciais() {
+    await Promise.all([
+      this.carregarClientes(),
+      this.carregarVeiculos(),
+      this.carregarPecas(),
+      this.carregarServicos(),
+      this.carregarOrdensServico(),
+    ]);
+  }
 
-  readonly servicos = signal<Servico[]>([
-    { id: 201, descricao: 'Troca de Óleo e Filtro', preco: 150.00 },
-    { id: 202, descricao: 'Alinhamento e Balanceamento', preco: 180.00 },
-    { id: 203, descricao: 'Revisão Sistema de Freios', preco: 250.00 },
-  ]);
+  async carregarClientes() {
+    if (this.modoOffline()) {
+      this.reaplicarClientesOffline();
+      return;
+    }
+    try {
+      const clientes = await firstValueFrom(this.http.get<Cliente[]>(`${this.apiUrl}/clientes`));
+      this.atualizarClientes(clientes);
+    } catch (error) {
+      console.error('Erro ao carregar clientes', error);
+      this.ativarModoOffline();
+    }
+  }
 
-  readonly ordensServico = signal<OrdemServico[]>([
-    {
-      id: 974,
-      veiculoId: 1,
-      clienteId: 1,
-      dataEntrada: '2025-09-07',
-      status: 'Em Andamento',
-      servicos: [{ id: 201, qtde: 1 }],
-      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
-    },
-    {
-      id: 973,
-      veiculoId: 1,
-      clienteId: 1,
-      dataEntrada: '2025-09-06',
-      status: 'Finalizada',
-      servicos: [{ id: 202, qtde: 1 }],
-      pecas: [],
-    },
-    {
-      id: 971,
-      veiculoId: 2,
-      clienteId: 3,
-      dataEntrada: '2025-09-05',
-      status: 'Aguardando Aprovação',
-      servicos: [{ id: 203, qtde: 1 }],
-      pecas: [{ id: 102, qtde: 2 }],
-    },
-    {
-      id: 968,
-      veiculoId: 3,
-      clienteId: 4,
-      dataEntrada: '2025-09-02',
-      status: 'Finalizada',
-      servicos: [{ id: 201, qtde: 1 }],
-      pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
-    },
-  ]);
+  async criarCliente(dados: Omit<Cliente, 'id'>) {
+    if (this.modoOffline()) {
+      return this.criarClienteOffline(dados);
+    }
 
-  constructor() { }
+    try {
+      const novo = await firstValueFrom(this.http.post<Cliente>(`${this.apiUrl}/clientes`, dados));
+      this.clientes.update(lista => [novo, ...lista.filter(cliente => cliente.id !== novo.id)]);
+      this.offlineState.clientes = deepClone(this.clientes());
+      return novo;
+    } catch (error) {
+      console.error('Erro ao criar cliente', error);
+      this.ativarModoOffline();
+      return this.criarClienteOffline(dados);
+    }
+  }
+
+  async atualizarCliente(id: number, dados: Omit<Cliente, 'id'>) {
+    if (this.modoOffline()) {
+      return this.atualizarClienteOffline(id, dados);
+    }
+
+    try {
+      const atualizado = await firstValueFrom(this.http.put<Cliente>(`${this.apiUrl}/clientes/${id}`, dados));
+      this.clientes.update(lista => lista.map(cliente => (cliente.id === id ? atualizado : cliente)));
+      this.offlineState.clientes = deepClone(this.clientes());
+      await this.carregarVeiculos();
+      return atualizado;
+    } catch (error) {
+      console.error('Erro ao atualizar cliente', error);
+      this.ativarModoOffline();
+      return this.atualizarClienteOffline(id, dados);
+    }
+  }
+
+  async removerCliente(id: number) {
+    if (this.modoOffline()) {
+      this.removerClienteOffline(id);
+      return;
+    }
+
+    try {
+      await firstValueFrom(this.http.delete<void>(`${this.apiUrl}/clientes/${id}`));
+      this.clientes.update(lista => lista.filter(cliente => cliente.id !== id));
+      this.veiculos.update(lista => lista.filter(veiculo => veiculo.clienteId !== id));
+      this.ordensServico.update(lista => lista.filter(ordem => ordem.clienteId !== id));
+      this.offlineState.clientes = deepClone(this.clientes());
+      this.offlineState.veiculos = deepClone(this.veiculos());
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+    } catch (error) {
+      console.error('Erro ao remover cliente', error);
+      this.ativarModoOffline();
+      this.removerClienteOffline(id);
+    }
+  }
+
+  async carregarVeiculos() {
+    if (this.modoOffline()) {
+      this.reaplicarVeiculosOffline();
+      return;
+    }
+    try {
+      const veiculos = await firstValueFrom(this.http.get<Veiculo[]>(`${this.apiUrl}/veiculos`));
+      this.atualizarVeiculos(veiculos);
+    } catch (error) {
+      console.error('Erro ao carregar veículos', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async criarVeiculo(dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    if (this.modoOffline()) {
+      return this.criarVeiculoOffline(dados);
+    }
+
+    try {
+      const novo = await firstValueFrom(this.http.post<Veiculo>(`${this.apiUrl}/veiculos`, dados));
+      this.veiculos.update(lista => [novo, ...lista.filter(veiculo => veiculo.id !== novo.id)]);
+      this.offlineState.veiculos = deepClone(this.veiculos());
+      return novo;
+    } catch (error) {
+      console.error('Erro ao criar veículo', error);
+      this.ativarModoOffline();
+      return this.criarVeiculoOffline(dados);
+    }
+  }
+
+  async atualizarVeiculo(id: number, dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    if (this.modoOffline()) {
+      return this.atualizarVeiculoOffline(id, dados);
+    }
+
+    try {
+      const atualizado = await firstValueFrom(this.http.put<Veiculo>(`${this.apiUrl}/veiculos/${id}`, dados));
+      this.veiculos.update(lista => lista.map(veiculo => (veiculo.id === id ? atualizado : veiculo)));
+      this.offlineState.veiculos = deepClone(this.veiculos());
+      return atualizado;
+    } catch (error) {
+      console.error('Erro ao atualizar veículo', error);
+      this.ativarModoOffline();
+      return this.atualizarVeiculoOffline(id, dados);
+    }
+  }
+
+  async removerVeiculo(id: number) {
+    if (this.modoOffline()) {
+      this.removerVeiculoOffline(id);
+      return;
+    }
+
+    try {
+      await firstValueFrom(this.http.delete<void>(`${this.apiUrl}/veiculos/${id}`));
+      this.veiculos.update(lista => lista.filter(veiculo => veiculo.id !== id));
+      this.ordensServico.update(lista => lista.filter(ordem => ordem.veiculoId !== id));
+      this.offlineState.veiculos = deepClone(this.veiculos());
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+    } catch (error) {
+      console.error('Erro ao remover veículo', error);
+      this.ativarModoOffline();
+      this.removerVeiculoOffline(id);
+    }
+  }
+
+  async carregarPecas() {
+    if (this.modoOffline()) {
+      this.reaplicarPecasOffline();
+      return;
+    }
+    try {
+      const pecas = await firstValueFrom(this.http.get<Peca[]>(`${this.apiUrl}/pecas`));
+      this.atualizarPecas(pecas);
+    } catch (error) {
+      console.error('Erro ao carregar peças', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async criarPeca(dados: Omit<Peca, 'id'>) {
+    if (this.modoOffline()) {
+      return this.criarPecaOffline(dados);
+    }
+
+    try {
+      const nova = await firstValueFrom(this.http.post<Peca>(`${this.apiUrl}/pecas`, dados));
+      this.pecas.update(lista => [nova, ...lista.filter(peca => peca.id !== nova.id)]);
+      this.offlineState.pecas = deepClone(this.pecas());
+      return nova;
+    } catch (error) {
+      console.error('Erro ao criar peça', error);
+      this.ativarModoOffline();
+      return this.criarPecaOffline(dados);
+    }
+  }
+
+  async atualizarPeca(id: number, dados: Omit<Peca, 'id'>) {
+    if (this.modoOffline()) {
+      return this.atualizarPecaOffline(id, dados);
+    }
+
+    try {
+      const atualizada = await firstValueFrom(this.http.put<Peca>(`${this.apiUrl}/pecas/${id}`, dados));
+      this.pecas.update(lista => lista.map(peca => (peca.id === id ? atualizada : peca)));
+      this.offlineState.pecas = deepClone(this.pecas());
+      return atualizada;
+    } catch (error) {
+      console.error('Erro ao atualizar peça', error);
+      this.ativarModoOffline();
+      return this.atualizarPecaOffline(id, dados);
+    }
+  }
+
+  async removerPeca(id: number) {
+    if (this.modoOffline()) {
+      this.removerPecaOffline(id);
+      return;
+    }
+
+    try {
+      await firstValueFrom(this.http.delete<void>(`${this.apiUrl}/pecas/${id}`));
+      this.pecas.update(lista => lista.filter(peca => peca.id !== id));
+      this.ordensServico.update(lista =>
+        lista.map(ordem => ({
+          ...ordem,
+          pecas: ordem.pecas.filter(item => item.id !== id)
+        }))
+      );
+      this.offlineState.pecas = deepClone(this.pecas());
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+    } catch (error) {
+      console.error('Erro ao remover peça', error);
+      this.ativarModoOffline();
+      this.removerPecaOffline(id);
+    }
+  }
+
+  async carregarServicos() {
+    if (this.modoOffline()) {
+      this.reaplicarServicosOffline();
+      return;
+    }
+    try {
+      const servicos = await firstValueFrom(this.http.get<Servico[]>(`${this.apiUrl}/servicos`));
+      this.atualizarServicos(servicos);
+    } catch (error) {
+      console.error('Erro ao carregar serviços', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async carregarOrdensServico() {
+    if (this.modoOffline()) {
+      this.reaplicarOrdensOffline();
+      return;
+    }
+    try {
+      const ordens = await firstValueFrom(this.http.get<OrdemServico[]>(`${this.apiUrl}/ordens-servico`));
+      this.atualizarOrdens(ordens);
+    } catch (error) {
+      console.error('Erro ao carregar ordens de serviço', error);
+      this.ativarModoOffline();
+    }
+  }
+
+  async criarOrdemServico(dados: Omit<OrdemServico, 'id'>) {
+    if (this.modoOffline()) {
+      return this.criarOrdemOffline(dados);
+    }
+
+    try {
+      const nova = await firstValueFrom(this.http.post<OrdemServico>(`${this.apiUrl}/ordens-servico`, dados));
+      this.ordensServico.update(lista => [nova, ...lista.filter(ordem => ordem.id !== nova.id)]);
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+      return nova;
+    } catch (error) {
+      console.error('Erro ao criar ordem de serviço', error);
+      this.ativarModoOffline();
+      return this.criarOrdemOffline(dados);
+    }
+  }
+
+  async atualizarOrdemServico(id: number, dados: Omit<OrdemServico, 'id'>) {
+    if (this.modoOffline()) {
+      return this.atualizarOrdemOffline(id, dados);
+    }
+
+    try {
+      const atualizada = await firstValueFrom(this.http.put<OrdemServico>(`${this.apiUrl}/ordens-servico/${id}`, dados));
+      this.ordensServico.update(lista => lista.map(ordem => (ordem.id === id ? atualizada : ordem)));
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+      return atualizada;
+    } catch (error) {
+      console.error('Erro ao atualizar ordem de serviço', error);
+      this.ativarModoOffline();
+      return this.atualizarOrdemOffline(id, dados);
+    }
+  }
+
+  async removerOrdemServico(id: number) {
+    if (this.modoOffline()) {
+      this.removerOrdemOffline(id);
+      return;
+    }
+
+    try {
+      await firstValueFrom(this.http.delete<void>(`${this.apiUrl}/ordens-servico/${id}`));
+      this.ordensServico.update(lista => lista.filter(ordem => ordem.id !== id));
+      this.offlineState.ordensServico = deepClone(this.ordensServico());
+    } catch (error) {
+      console.error('Erro ao remover ordem de serviço', error);
+      this.ativarModoOffline();
+      this.removerOrdemOffline(id);
+    }
+  }
 
   getOrdemServicoById(id: number): OrdemServico | undefined {
     return this.ordensServico().find(os => os.id === id);
+  }
+
+  private ativarModoOffline() {
+    if (this.modoOffline()) {
+      return;
+    }
+    this.modoOffline.set(true);
+    console.warn('API indisponível. Entrando em modo offline com dados locais.');
+    this.reaplicarClientesOffline();
+    this.reaplicarVeiculosOffline();
+    this.reaplicarPecasOffline();
+    this.reaplicarServicosOffline();
+    this.reaplicarOrdensOffline();
+  }
+
+  private gerarProximoId(lista: { id: number }[]) {
+    return lista.reduce((max, item) => (item.id > max ? item.id : max), 0) + 1;
+  }
+
+  private reaplicarClientesOffline() {
+    this.clientes.set(sortByIdDesc(deepClone(this.offlineState.clientes)));
+  }
+
+  private reaplicarVeiculosOffline() {
+    this.veiculos.set(sortByIdDesc(deepClone(this.offlineState.veiculos)));
+  }
+
+  private reaplicarPecasOffline() {
+    this.pecas.set(sortByIdDesc(deepClone(this.offlineState.pecas)));
+  }
+
+  private reaplicarServicosOffline() {
+    this.servicos.set(sortByIdDesc(deepClone(this.offlineState.servicos)));
+  }
+
+  private reaplicarOrdensOffline() {
+    this.ordensServico.set(sortByIdDesc(deepClone(this.offlineState.ordensServico)));
+  }
+
+  private atualizarClientes(clientes: Cliente[]) {
+    const ordenados = sortByIdDesc(clientes);
+    const copiados = deepClone(ordenados);
+    this.clientes.set(copiados);
+    this.offlineState.clientes = deepClone(copiados);
+  }
+
+  private atualizarVeiculos(veiculos: Veiculo[]) {
+    const ordenados = sortByIdDesc(veiculos);
+    const copiados = deepClone(ordenados);
+    this.veiculos.set(copiados);
+    this.offlineState.veiculos = deepClone(copiados);
+  }
+
+  private atualizarPecas(pecas: Peca[]) {
+    const ordenadas = sortByIdDesc(pecas);
+    const copiadas = deepClone(ordenadas);
+    this.pecas.set(copiadas);
+    this.offlineState.pecas = deepClone(copiadas);
+  }
+
+  private atualizarServicos(servicos: Servico[]) {
+    const ordenados = sortByIdDesc(servicos);
+    const copiados = deepClone(ordenados);
+    this.servicos.set(copiados);
+    this.offlineState.servicos = deepClone(copiados);
+  }
+
+  private atualizarOrdens(ordens: OrdemServico[]) {
+    const ordenadas = sortByIdDesc(ordens);
+    const copiadas = deepClone(ordenadas);
+    this.ordensServico.set(copiadas);
+    this.offlineState.ordensServico = deepClone(copiadas);
+  }
+
+  private removerClienteOffline(id: number) {
+    const clientes = this.offlineState.clientes.filter(cliente => cliente.id !== id);
+    if (clientes.length === this.offlineState.clientes.length) {
+      return;
+    }
+    this.offlineState.clientes = clientes;
+    this.offlineState.veiculos = this.offlineState.veiculos.filter(veiculo => veiculo.clienteId !== id);
+    this.offlineState.ordensServico = this.offlineState.ordensServico.filter(ordem => ordem.clienteId !== id);
+    this.reaplicarClientesOffline();
+    this.reaplicarVeiculosOffline();
+    this.reaplicarOrdensOffline();
+  }
+
+  private removerVeiculoOffline(id: number) {
+    const veiculos = this.offlineState.veiculos.filter(veiculo => veiculo.id !== id);
+    if (veiculos.length === this.offlineState.veiculos.length) {
+      return;
+    }
+    this.offlineState.veiculos = veiculos;
+    this.offlineState.ordensServico = this.offlineState.ordensServico.filter(ordem => ordem.veiculoId !== id);
+    this.reaplicarVeiculosOffline();
+    this.reaplicarOrdensOffline();
+  }
+
+  private removerPecaOffline(id: number) {
+    const pecas = this.offlineState.pecas.filter(peca => peca.id !== id);
+    if (pecas.length === this.offlineState.pecas.length) {
+      return;
+    }
+    this.offlineState.pecas = pecas;
+    this.offlineState.ordensServico = this.offlineState.ordensServico.map(ordem => ({
+      ...ordem,
+      pecas: ordem.pecas.filter(item => item.id !== id)
+    }));
+    this.reaplicarPecasOffline();
+    this.reaplicarOrdensOffline();
+  }
+
+  private removerOrdemOffline(id: number) {
+    const ordens = this.offlineState.ordensServico.filter(ordem => ordem.id !== id);
+    if (ordens.length === this.offlineState.ordensServico.length) {
+      return;
+    }
+    this.offlineState.ordensServico = ordens;
+    this.reaplicarOrdensOffline();
+  }
+
+  private criarClienteOffline(dados: Omit<Cliente, 'id'>) {
+    const novo: Cliente = { id: this.gerarProximoId(this.offlineState.clientes), ...dados };
+    const atualizados = [novo, ...this.offlineState.clientes];
+    this.atualizarClientes(atualizados);
+    this.atualizarVeiculos(
+      this.offlineState.veiculos.map(veiculo =>
+        veiculo.clienteId === novo.id ? { ...veiculo, clienteNome: novo.nome } : veiculo
+      )
+    );
+    return novo;
+  }
+
+  private atualizarClienteOffline(id: number, dados: Omit<Cliente, 'id'>) {
+    let atualizado: Cliente | undefined;
+    const atualizados = this.offlineState.clientes.map(cliente => {
+      if (cliente.id === id) {
+        atualizado = { ...cliente, ...dados };
+        return atualizado;
+      }
+      return cliente;
+    });
+    if (!atualizado) {
+      return undefined;
+    }
+    this.atualizarClientes(atualizados);
+    this.atualizarVeiculos(
+      this.offlineState.veiculos.map(veiculo =>
+        veiculo.clienteId === id ? { ...veiculo, clienteNome: atualizado!.nome } : veiculo
+      )
+    );
+    return atualizado;
+  }
+
+  private criarVeiculoOffline(dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    const cliente = this.clientes().find(item => item.id === dados.clienteId);
+    const novo: Veiculo = {
+      id: this.gerarProximoId(this.offlineState.veiculos),
+      ...dados,
+      clienteNome: cliente ? cliente.nome : 'Cliente não encontrado'
+    };
+    const atualizados = [novo, ...this.offlineState.veiculos];
+    this.atualizarVeiculos(atualizados);
+    return novo;
+  }
+
+  private atualizarVeiculoOffline(id: number, dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
+    const cliente = this.clientes().find(item => item.id === dados.clienteId);
+    let atualizado: Veiculo | undefined;
+    const atualizados = this.offlineState.veiculos.map(veiculo => {
+      if (veiculo.id === id) {
+        atualizado = {
+          ...veiculo,
+          ...dados,
+          clienteNome: cliente ? cliente.nome : 'Cliente não encontrado'
+        };
+        return atualizado;
+      }
+      return veiculo;
+    });
+    if (!atualizado) {
+      return undefined;
+    }
+    this.atualizarVeiculos(atualizados);
+    return atualizado;
+  }
+
+  private criarPecaOffline(dados: Omit<Peca, 'id'>) {
+    const nova: Peca = { id: this.gerarProximoId(this.offlineState.pecas), ...dados };
+    const atualizadas = [nova, ...this.offlineState.pecas];
+    this.atualizarPecas(atualizadas);
+    return nova;
+  }
+
+  private atualizarPecaOffline(id: number, dados: Omit<Peca, 'id'>) {
+    let atualizada: Peca | undefined;
+    const atualizadas = this.offlineState.pecas.map(peca => {
+      if (peca.id === id) {
+        atualizada = { ...peca, ...dados };
+        return atualizada;
+      }
+      return peca;
+    });
+    if (!atualizada) {
+      return undefined;
+    }
+    this.atualizarPecas(atualizadas);
+    return atualizada;
+  }
+
+  private criarOrdemOffline(dados: Omit<OrdemServico, 'id'>) {
+    const nova: OrdemServico = {
+      id: this.gerarProximoId(this.offlineState.ordensServico),
+      ...deepClone(dados)
+    };
+    const atualizadas = [nova, ...this.offlineState.ordensServico];
+    this.atualizarOrdens(atualizadas);
+    return nova;
+  }
+
+  private atualizarOrdemOffline(id: number, dados: Omit<OrdemServico, 'id'>) {
+    let atualizada: OrdemServico | undefined;
+    const atualizadas = this.offlineState.ordensServico.map(ordem => {
+      if (ordem.id === id) {
+        atualizada = { ...ordem, ...deepClone(dados) };
+        return atualizada;
+      }
+      return ordem;
+    });
+    if (!atualizada) {
+      return undefined;
+    }
+    this.atualizarOrdens(atualizadas);
+    return atualizada;
   }
 }

--- a/src/app/pages/login.component.ts
+++ b/src/app/pages/login.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+import { AuthService } from '../core/services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -20,6 +22,13 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
         </div>
 
         <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-6">
+          @if (erroLogin()) {
+            <div class="flex items-center gap-3 rounded-2xl border border-rose-400/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 19.07A10 10 0 1 1 19.07 4.93 10 10 0 0 1 4.93 19.07z" /></svg>
+              <span>{{ erroLogin() }}</span>
+            </div>
+          }
+
           <div>
             <label class="mb-2 block text-sm font-medium text-slate-200" for="email">E-mail</label>
             <input
@@ -51,30 +60,65 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
           <button
             type="submit"
             class="w-full rounded-full bg-gradient-to-r from-sky-500 via-blue-500 to-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/40 transition hover:from-sky-400 hover:via-blue-400 hover:to-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-            [disabled]="form.invalid"
+            [disabled]="form.invalid || carregando()"
           >
-            Entrar
+            {{ carregando() ? 'Validando acesso...' : 'Entrar' }}
           </button>
         </form>
+
+        <div class="mt-8 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300/90">
+          <p class="font-semibold text-slate-100">Acesso rápido</p>
+          <p class="mt-2">Use <span class="font-medium text-white">admin@oficinapro.com</span> com senha <span class="font-medium text-white">admin123</span> para entrar como administrador.</p>
+        </div>
       </div>
     </div>
   `,
 })
 export class LoginComponent {
   private fb = new FormBuilder();
+  private authService = inject(AuthService);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+
+  erroLogin = signal<string | null>(null);
+  carregando = signal(false);
 
   form = this.fb.group({
     email: ['', [Validators.required, Validators.email]],
     password: ['', [Validators.required, Validators.minLength(6)]],
   });
 
-  onSubmit() {
+  constructor() {
+    effect(() => {
+      if (this.authService.estaAutenticado()) {
+        void this.router.navigate(['/inicio']);
+      }
+    });
+  }
+
+  async onSubmit() {
     this.form.markAllAsTouched();
     if (this.form.invalid) {
       return;
     }
 
-    // Futuramente, integrar com serviço de autenticação.
-    console.log('Login realizado', this.form.value);
+    const email = this.form.value.email ?? '';
+    const senha = this.form.value.password ?? '';
+    this.carregando.set(true);
+    this.erroLogin.set(null);
+
+    try {
+      await this.authService.login(email, senha);
+      const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') || '/inicio';
+      void this.router.navigateByUrl(returnUrl);
+    } catch (error: any) {
+      if (error?.status === 401) {
+        this.erroLogin.set('Credenciais inválidas. Verifique e tente novamente.');
+      } else {
+        this.erroLogin.set('Não foi possível validar o acesso no momento. Tente novamente em instantes.');
+      }
+    } finally {
+      this.carregando.set(false);
+    }
   }
 }

--- a/src/app/pages/ordens-servico.component.ts
+++ b/src/app/pages/ordens-servico.component.ts
@@ -35,7 +35,21 @@ import { DataService } from '../core/services/data.service';
         </div>
 
         @if (modoVisualizacao() === 'lista') {
-          <div class="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+          <div class="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <label class="flex w-full items-center gap-2 rounded-full border border-white/10 bg-slate-900/40 px-4 py-2 text-sm text-slate-200 focus-within:border-sky-400 focus-within:ring-2 focus-within:ring-sky-400/30">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m21 21-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" /></svg>
+                <input
+                  class="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-400 focus:outline-none"
+                  type="search"
+                  placeholder="Pesquisar por cliente, veículo, status ou número da OS"
+                  [(ngModel)]="termoBuscaValor"
+                  name="buscaOrdens"
+                />
+              </label>
+              <span class="text-xs uppercase tracking-[0.3em] text-slate-400">{{ ordensFiltradas().length }} resultado(s)</span>
+            </div>
+            <div class="overflow-hidden rounded-xl border border-white/10 bg-white/5">
             <div class="overflow-x-auto">
               <table class="min-w-full divide-y divide-white/10 text-left text-sm text-slate-100">
                 <thead class="bg-white/5 text-xs uppercase tracking-wider text-slate-300">
@@ -48,7 +62,12 @@ import { DataService } from '../core/services/data.service';
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-white/5 text-sm">
-                  @for (os of ordensServico(); track os.id) {
+                  @if (ordensFiltradas().length === 0) {
+                    <tr>
+                      <td class="px-6 py-6 text-center text-slate-400" colspan="5">Nenhuma ordem de serviço encontrada com os critérios informados.</td>
+                    </tr>
+                  }
+                  @for (os of ordensFiltradas(); track os.id) {
                     <tr class="transition hover:bg-white/5">
                       <td class="whitespace-nowrap px-6 py-4 font-semibold text-sky-300">#{{ os.id }}</td>
                       <td class="px-6 py-4">{{ getVeiculo(os.veiculoId)?.placa }}</td>
@@ -66,6 +85,7 @@ import { DataService } from '../core/services/data.service';
                   }
                 </tbody>
               </table>
+            </div>
             </div>
           </div>
         }
@@ -173,14 +193,26 @@ import { DataService } from '../core/services/data.service';
                 <h3 class="text-lg font-semibold text-white">Resumo da ordem #{{ ordemSelecionada()?.id }}</h3>
                 <p class="text-sm text-slate-300/80">Veja o panorama completo de serviços, peças e anotações.</p>
               </div>
+              <div class="flex flex-wrap gap-2 text-sm">
+                <button class="rounded-full border border-white/15 bg-white/5 px-4 py-2 font-medium text-slate-200 transition hover:bg-white/10" (click)="voltarParaLista()">
+                  Voltar
+                </button>
+                <button class="rounded-full bg-gradient-to-r from-emerald-400 via-teal-400 to-sky-500 px-4 py-2 font-semibold text-slate-950 shadow shadow-emerald-500/30 transition hover:from-emerald-300 hover:via-teal-300 hover:to-sky-400" (click)="imprimirResumo()">
+                  Imprimir resumo
+                </button>
+                <button class="rounded-full border border-rose-400/60 bg-rose-500/10 px-4 py-2 font-semibold text-rose-200 transition hover:bg-rose-500/20" (click)="excluirOrdemSelecionada()">
+                  Excluir ordem
+                </button>
+              </div>
             </div>
 
-            <div class="grid gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-slate-200 md:grid-cols-2">
-              <div>
-                <span class="block text-xs font-semibold uppercase tracking-wide text-slate-400">Cliente</span>
-                <span class="text-base text-white">{{ getCliente(ordemSelecionada()!.clienteId)?.nome }}</span>
-              </div>
-              <div>
+            <div class="space-y-4">
+              <div class="grid gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-slate-200 md:grid-cols-2">
+                <div>
+                  <span class="block text-xs font-semibold uppercase tracking-wide text-slate-400">Cliente</span>
+                  <span class="text-base text-white">{{ getCliente(ordemSelecionada()!.clienteId)?.nome }}</span>
+                </div>
+                <div>
                 <span class="block text-xs font-semibold uppercase tracking-wide text-slate-400">Veículo</span>
                 <span class="text-base text-white">
                   {{ getVeiculo(ordemSelecionada()!.veiculoId)?.marca }} {{ getVeiculo(ordemSelecionada()!.veiculoId)?.modelo }}
@@ -197,13 +229,13 @@ import { DataService } from '../core/services/data.service';
                   {{ ordemSelecionada()!.status }}
                 </span>
               </div>
-              <div class="md:col-span-2">
-                <span class="block text-xs font-semibold uppercase tracking-wide text-slate-400">Observações</span>
-                <p class="mt-1 text-base text-slate-200/90">{{ ordemSelecionada()!.observacoes || 'Sem observações registradas.' }}</p>
+                <div class="md:col-span-2">
+                  <span class="block text-xs font-semibold uppercase tracking-wide text-slate-400">Observações</span>
+                  <p class="mt-1 text-base text-slate-200/90">{{ ordemSelecionada()!.observacoes || 'Sem observações registradas.' }}</p>
+                </div>
               </div>
-            </div>
 
-            <div class="grid gap-4 md:grid-cols-2">
+              <div class="grid gap-4 md:grid-cols-2">
               <div class="rounded-2xl border border-white/10 bg-white/5 p-5">
                 <h4 class="text-sm font-semibold uppercase tracking-wider text-slate-200">Serviços</h4>
                 <ul class="mt-3 space-y-2 text-sm text-slate-200">
@@ -235,6 +267,7 @@ import { DataService } from '../core/services/data.service';
                 </ul>
               </div>
             </div>
+            </div>
           </div>
         }
       </div>
@@ -252,6 +285,7 @@ export class OrdensServicoComponent {
 
   modoVisualizacao = signal<'lista' | 'formulario' | 'resumo'>('lista');
   ordemSelecionadaId = signal<number | null>(null);
+  termoBusca = signal('');
 
   formularioOrdem = {
     clienteId: undefined as number | undefined,
@@ -269,6 +303,23 @@ export class OrdensServicoComponent {
     return this.dataService.getOrdemServicoById(id);
   });
 
+  ordensFiltradas = computed(() => {
+    const termo = this.termoBusca().toLowerCase().trim();
+    if (!termo) {
+      return this.ordensServico();
+    }
+    return this.ordensServico().filter(ordem => {
+      const cliente = this.getCliente(ordem.clienteId)?.nome ?? '';
+      const veiculo = this.getVeiculo(ordem.veiculoId);
+      const placa = veiculo?.placa ?? '';
+      const modelo = veiculo ? `${veiculo.marca} ${veiculo.modelo}` : '';
+      return [ordem.id.toString(), cliente, placa, modelo, ordem.status]
+        .join(' ')
+        .toLowerCase()
+        .includes(termo);
+    });
+  });
+
   abrirFormulario() {
     this.limparFormulario();
     this.modoVisualizacao.set('formulario');
@@ -284,27 +335,27 @@ export class OrdensServicoComponent {
     this.ordemSelecionadaId.set(null);
   }
 
-  salvarOrdem() {
+  async salvarOrdem() {
     if (!this.formularioOrdem.clienteId || !this.formularioOrdem.veiculoId || !this.formularioOrdem.dataEntrada || !this.formularioOrdem.status) {
       return;
     }
 
-    const novaOrdemId = this.ordensServico().reduce((max, os) => Math.max(max, os.id), 0) + 1;
-    this.dataService.ordensServico.update(ordens => [
-      {
-        id: novaOrdemId,
-        clienteId: this.formularioOrdem.clienteId!,
-        veiculoId: this.formularioOrdem.veiculoId!,
-        dataEntrada: this.formularioOrdem.dataEntrada,
-        status: this.formularioOrdem.status!,
-        servicos: [],
-        pecas: [],
-        observacoes: this.formularioOrdem.observacoes?.trim() || undefined,
-      },
-      ...ordens,
-    ]);
+    const dados = {
+      clienteId: this.formularioOrdem.clienteId!,
+      veiculoId: this.formularioOrdem.veiculoId!,
+      dataEntrada: this.formularioOrdem.dataEntrada,
+      status: this.formularioOrdem.status!,
+      servicos: [],
+      pecas: [],
+      observacoes: this.formularioOrdem.observacoes?.trim() || undefined,
+    };
 
-    this.voltarParaLista();
+    try {
+      await this.dataService.criarOrdemServico(dados);
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao salvar ordem de serviço', error);
+    }
   }
 
   getVeiculo(id: number) {
@@ -330,6 +381,196 @@ export class OrdensServicoComponent {
     return this.pecas().find(p => p.id === id);
   }
 
+  async excluirOrdemSelecionada() {
+    const id = this.ordemSelecionadaId();
+    if (!id) {
+      return;
+    }
+
+    const confirmacao = confirm('Deseja realmente excluir esta ordem de serviço?');
+    if (!confirmacao) {
+      return;
+    }
+
+    try {
+      await this.dataService.removerOrdemServico(id);
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao remover ordem de serviço', error);
+    }
+  }
+
+  imprimirResumo() {
+    const ordem = this.ordemSelecionada();
+    if (!ordem) {
+      return;
+    }
+
+    const cliente = this.getCliente(ordem.clienteId);
+    const veiculo = this.getVeiculo(ordem.veiculoId);
+
+    const servicosDetalhados = ordem.servicos.map(item => {
+      const servico = this.getServico(item.id);
+      const preco = servico?.preco ?? 0;
+      return {
+        descricao: servico?.descricao ?? 'Serviço',
+        qtde: item.qtde,
+        preco,
+        subtotal: preco * item.qtde
+      };
+    });
+
+    const pecasDetalhadas = ordem.pecas.map(item => {
+      const peca = this.getPeca(item.id);
+      const preco = peca?.preco ?? 0;
+      return {
+        descricao: peca?.nome ?? 'Peça',
+        qtde: item.qtde,
+        preco,
+        subtotal: preco * item.qtde
+      };
+    });
+
+    const totalServicos = servicosDetalhados.reduce((total, item) => total + item.subtotal, 0);
+    const totalPecas = pecasDetalhadas.reduce((total, item) => total + item.subtotal, 0);
+    const totalGeral = totalServicos + totalPecas;
+
+    const tabelaServicos = servicosDetalhados.length
+      ? servicosDetalhados
+          .map(
+            item => `
+            <tr>
+              <td>${item.descricao}</td>
+              <td class="center">${item.qtde}</td>
+              <td class="right">${this.formatarMoeda(item.preco)}</td>
+              <td class="right">${this.formatarMoeda(item.subtotal)}</td>
+            </tr>
+          `
+          )
+          .join('')
+      : '<tr><td colspan="4" class="center">Nenhum serviço vinculado.</td></tr>';
+
+    const tabelaPecas = pecasDetalhadas.length
+      ? pecasDetalhadas
+          .map(
+            item => `
+            <tr>
+              <td>${item.descricao}</td>
+              <td class="center">${item.qtde}</td>
+              <td class="right">${this.formatarMoeda(item.preco)}</td>
+              <td class="right">${this.formatarMoeda(item.subtotal)}</td>
+            </tr>
+          `
+          )
+          .join('')
+      : '<tr><td colspan="4" class="center">Nenhuma peça vinculada.</td></tr>';
+
+    const janela = window.open('', '_blank', 'width=900,height=650');
+    if (!janela) {
+      return;
+    }
+
+    janela.document.write(`
+      <html>
+        <head>
+          <title>Resumo OS #${ordem.id}</title>
+          <style>
+            body { font-family: 'Inter', system-ui, -apple-system, sans-serif; color: #0f172a; padding: 32px; background: #f8fafc; }
+            h1 { margin-bottom: 4px; }
+            h2 { margin-top: 32px; }
+            .subtle { color: #475569; margin: 0; }
+            .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 24px; }
+            .card { background: #ffffff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 20px; box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08); }
+            table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+            th, td { border: 1px solid #e2e8f0; padding: 10px 14px; }
+            th { background: #f1f5f9; text-align: left; font-weight: 600; }
+            .right { text-align: right; }
+            .center { text-align: center; }
+            .totais { max-width: 280px; margin-left: auto; margin-top: 16px; }
+            .totais div { display: flex; justify-content: space-between; margin-bottom: 8px; }
+            .totais strong { font-size: 18px; }
+            .badge { display: inline-flex; padding: 6px 14px; border-radius: 999px; background: #e0f2fe; color: #0c4a6e; font-size: 12px; margin-top: 4px; }
+          </style>
+        </head>
+        <body>
+          <header>
+            <h1>OficinaPRO</h1>
+            <p class="subtle">Rua das Mecânicas, 123 - Bairro Industrial · Uberlândia - MG · (34) 99999-8888</p>
+            <span class="badge">Ordem de Serviço #${ordem.id}</span>
+          </header>
+
+          <section class="grid">
+            <div class="card">
+              <h2>Cliente</h2>
+              <p>${cliente?.nome ?? 'Cliente não informado'}</p>
+            </div>
+            <div class="card">
+              <h2>Veículo</h2>
+              <p>${veiculo ? `${veiculo.marca} ${veiculo.modelo} (${veiculo.placa})` : 'Veículo não informado'}</p>
+            </div>
+            <div class="card">
+              <h2>Detalhes</h2>
+              <p>Entrada: ${new Date(ordem.dataEntrada).toLocaleDateString('pt-BR')}</p>
+              <p>Status: ${ordem.status}</p>
+            </div>
+            <div class="card">
+              <h2>Observações</h2>
+              <p>${ordem.observacoes ?? 'Sem observações registradas.'}</p>
+            </div>
+          </section>
+
+          <section class="card" style="margin-top: 32px;">
+            <h2>Serviços</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Descrição</th>
+                  <th class="center">Qtde</th>
+                  <th class="right">Valor unitário</th>
+                  <th class="right">Subtotal</th>
+                </tr>
+              </thead>
+              <tbody>${tabelaServicos}</tbody>
+            </table>
+          </section>
+
+          <section class="card" style="margin-top: 24px;">
+            <h2>Peças</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Descrição</th>
+                  <th class="center">Qtde</th>
+                  <th class="right">Valor unitário</th>
+                  <th class="right">Subtotal</th>
+                </tr>
+              </thead>
+              <tbody>${tabelaPecas}</tbody>
+            </table>
+          </section>
+
+          <div class="totais card">
+            <div><span>Total de serviços:</span><span>${this.formatarMoeda(totalServicos)}</span></div>
+            <div><span>Total de peças:</span><span>${this.formatarMoeda(totalPecas)}</span></div>
+            <div><strong>Valor total:</strong><strong>${this.formatarMoeda(totalGeral)}</strong></div>
+          </div>
+
+          <footer style="margin-top: 40px; text-align: center; color: #475569; font-size: 13px;">
+            <p>Todos os serviços e produtos possuem garantia de 3 meses.</p>
+            <p><strong>Obrigado pela preferência!</strong></p>
+          </footer>
+        </body>
+      </html>
+    `);
+    janela.document.close();
+    janela.focus();
+    janela.print();
+  }
+
+  private formatarMoeda(valor: number) {
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(valor);
+  }
+
   private limparFormulario() {
     this.formularioOrdem = {
       clienteId: undefined,
@@ -338,5 +579,13 @@ export class OrdensServicoComponent {
       status: undefined,
       observacoes: '',
     };
+  }
+
+  get termoBuscaValor() {
+    return this.termoBusca();
+  }
+
+  set termoBuscaValor(valor: string) {
+    this.termoBusca.set(valor);
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable authentication service, route guard, and login UX updates that redirect users after sign-in and display active profile data across the shell
- extend the workshop dashboards with search filters, in-form deletions, and printable order-of-service summaries backed by richer DataService helpers
- introduce backend login support plus DELETE endpoints and user seed data so API and offline modes stay synchronized when removing records

## Testing
- npm run build *(fails: Angular CLI binaries are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eaede5540483219d95a4a69408a9c3