### PR TITLE
Add authentication and management enhancements

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -68,6 +68,15 @@ const defaultData = {
       pecas: [{ id: 101, qtde: 1 }, { id: 104, qtde: 1 }],
       observacoes: 'Veículo entregue ao cliente.'
     }
+  ],
+  usuarios: [
+    {
+      id: 1,
+      nome: 'Administrador',
+      email: 'admin@planucenter.com',
+      senhaHash: '240be518fabd2724ddb6f04eeb1da5967448d7e831c08c8fa822809f74c720a9',
+      perfil: 'admin'
+    }
   ]
 };
 
@@ -119,6 +128,10 @@ function getServicos() {
 
 function getOrdensServico() {
   return data.ordensServico;
+}
+
+function getUsuarios() {
+  return data.usuarios;
 }
 
 function nextId(collectionName) {
@@ -215,12 +228,80 @@ function updateOrdemServico(id, updates) {
   return atualizada;
 }
 
+function deleteCliente(id) {
+  const exists = data.clientes.some(cliente => cliente.id === id);
+  if (!exists) {
+    return false;
+  }
+
+  const veiculosRemovidos = new Set();
+
+  data.clientes = data.clientes.filter(cliente => cliente.id !== id);
+  data.veiculos = data.veiculos.filter(veiculo => {
+    if (veiculo.clienteId === id) {
+      veiculosRemovidos.add(veiculo.id);
+      return false;
+    }
+    return true;
+  });
+
+  if (veiculosRemovidos.size > 0) {
+    data.ordensServico = data.ordensServico.filter(ordem => !veiculosRemovidos.has(ordem.veiculoId));
+  }
+
+  data.ordensServico = data.ordensServico.filter(ordem => ordem.clienteId !== id);
+
+  saveDatabase();
+  return true;
+}
+
+function deleteVeiculo(id) {
+  const exists = data.veiculos.some(veiculo => veiculo.id === id);
+  if (!exists) {
+    return false;
+  }
+
+  data.veiculos = data.veiculos.filter(veiculo => veiculo.id !== id);
+  data.ordensServico = data.ordensServico.filter(ordem => ordem.veiculoId !== id);
+
+  saveDatabase();
+  return true;
+}
+
+function deletePeca(id) {
+  const exists = data.pecas.some(peca => peca.id === id);
+  if (!exists) {
+    return false;
+  }
+
+  data.pecas = data.pecas.filter(peca => peca.id !== id);
+  data.ordensServico = data.ordensServico.map(ordem => ({
+    ...ordem,
+    pecas: ordem.pecas.filter(item => item.id !== id)
+  }));
+
+  saveDatabase();
+  return true;
+}
+
+function deleteOrdemServico(id) {
+  const exists = data.ordensServico.some(ordem => ordem.id === id);
+  if (!exists) {
+    return false;
+  }
+
+  data.ordensServico = data.ordensServico.filter(ordem => ordem.id !== id);
+  saveDatabase();
+  return true;
+}
+
 module.exports = {
   getClientes,
   getVeiculos,
   getPecas,
   getServicos,
   getOrdensServico,
+  getUsuarios,
   addCliente,
   updateCliente,
   addVeiculo,
@@ -229,6 +310,10 @@ module.exports = {
   updatePeca,
   addOrdemServico,
   updateOrdemServico,
+  deleteCliente,
+  deleteVeiculo,
+  deletePeca,
+  deleteOrdemServico,
   nextId,
   saveDatabase,
   data

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -23,19 +23,21 @@
         </div>
 
         <div class="relative">
-          <button
-            class="flex items-center rounded-full bg-white/10 pl-2 pr-3 text-left text-sm text-slate-100 transition hover:bg-white/20"
-            (click)="toggleProfileMenu()"
-          >
-            <div class="mr-2 h-9 w-9 rounded-full bg-gradient-to-br from-sky-500 via-blue-500 to-indigo-600 text-white flex items-center justify-center font-semibold shadow-lg shadow-sky-500/40">
-              A
-            </div>
-            <div class="hidden sm:block leading-tight">
-              <p class="font-semibold text-slate-100">Admin</p>
-              <p class="text-xs text-slate-300/80">Administrador</p>
-            </div>
-            <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 h-4 w-4 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9 6 6 6-6" /></svg>
-          </button>
+          @if (usuarioAtual(); as usuario) {
+            <button
+              class="flex items-center rounded-full bg-white/10 pl-2 pr-3 text-left text-sm text-slate-100 transition hover:bg-white/20"
+              (click)="toggleProfileMenu()"
+            >
+              <div class="mr-2 h-9 w-9 rounded-full bg-gradient-to-br from-sky-500 via-blue-500 to-indigo-600 text-white flex items-center justify-center font-semibold shadow-lg shadow-sky-500/40">
+                {{ avatarInicial() }}
+              </div>
+              <div class="hidden sm:block leading-tight">
+                <p class="font-semibold text-slate-100">{{ usuario.nome }}</p>
+                <p class="text-xs text-slate-300/80">{{ perfilUsuario() || 'Usuário' }}</p>
+              </div>
+              <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 h-4 w-4 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9 6 6 6-6" /></svg>
+            </button>
+          }
 
           @if (isProfileMenuOpen()) {
             <div class="absolute right-0 mt-2 w-48 rounded-2xl border border-white/10 bg-slate-950/90 p-2 text-sm shadow-xl shadow-slate-950/60 backdrop-blur">

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,15 +6,16 @@ import { ResumoOsComponent } from './pages/resumo-os.component';
 import { VeiculosComponent } from './pages/veiculos.component';
 import { LoginComponent } from './pages/login.component';
 import { ClientesComponent } from './pages/clientes.component';
+import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
     { path: 'login', component: LoginComponent },
-    { path: 'inicio', component: DashboardComponent },
-    { path: 'ordens-servico', component: OrdensServicoComponent },
-    { path: 'ordens-servico/:id', component: ResumoOsComponent },
-    { path: 'veiculos', component: VeiculosComponent },
-    { path: 'estoque', component: EstoqueComponent },
-    { path: 'clientes', component: ClientesComponent },
+    { path: 'inicio', component: DashboardComponent, canActivate: [authGuard] },
+    { path: 'ordens-servico', component: OrdensServicoComponent, canActivate: [authGuard] },
+    { path: 'ordens-servico/:id', component: ResumoOsComponent, canActivate: [authGuard] },
+    { path: 'veiculos', component: VeiculosComponent, canActivate: [authGuard] },
+    { path: 'estoque', component: EstoqueComponent, canActivate: [authGuard] },
+    { path: 'clientes', component: ClientesComponent, canActivate: [authGuard] },
 
     { path: '', redirectTo: '/login', pathMatch: 'full' }, // Redireciona a raiz para a tela de login
     { path: '**', redirectTo: '/login' } // Rota curinga para qualquer URL inválida

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,6 +4,7 @@ import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './layout/sidebar.component';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter, map, startWith } from 'rxjs';
+import { AuthService } from './core/services/auth.service';
 
 @Component({
   selector: 'app-root',
@@ -14,6 +15,7 @@ import { filter, map, startWith } from 'rxjs';
 })
 export class App {
   private router = inject(Router);
+  private authService = inject(AuthService);
 
   isMobileMenuOpen = signal(false);
   private profileMenuOpen = signal(false);
@@ -29,6 +31,19 @@ export class App {
 
   isLoginRoute = computed(() => this.currentUrl().startsWith('/login'));
   isProfileMenuOpen = computed(() => this.profileMenuOpen());
+  usuarioAtual = this.authService.usuarioAtual;
+  nomeUsuario = computed(() => this.usuarioAtual()?.nome ?? '');
+  perfilUsuario = computed(() => {
+    const perfil = this.usuarioAtual()?.perfil ?? '';
+    if (!perfil) {
+      return '';
+    }
+    return perfil.charAt(0).toUpperCase() + perfil.slice(1);
+  });
+  avatarInicial = computed(() => {
+    const nome = this.nomeUsuario();
+    return nome ? nome.charAt(0).toUpperCase() : '?';
+  });
 
   toggleProfileMenu(): void {
     this.profileMenuOpen.update(value => !value);
@@ -37,6 +52,6 @@ export class App {
   logout(): void {
     this.profileMenuOpen.set(false);
     this.isMobileMenuOpen.set(false);
-    void this.router.navigate(['/login']);
+    this.authService.logout();
   }
 }

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.autenticado()) {
+    return true;
+  }
+
+  void router.navigate(['/login']);
+  return false;
+};

--- a/src/app/core/models/models.ts
+++ b/src/app/core/models/models.ts
@@ -48,3 +48,10 @@ export interface MenuItem {
   path: string;
   iconPath: string;
 }
+
+export interface UsuarioAutenticado {
+  id: number;
+  nome: string;
+  email: string;
+  perfil: 'admin' | 'usuario';
+}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { Router } from '@angular/router';
+import { UsuarioAutenticado } from '../models/models';
+
+interface LoginResponse {
+  token: string;
+  usuario: UsuarioAutenticado;
+}
+
+interface AuthState {
+  usuario: UsuarioAutenticado | null;
+  token: string | null;
+}
+
+const STORAGE_KEY = 'planu-center-auth';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+  private router = inject(Router);
+
+  private readonly apiUrl = 'http://localhost:3000/api';
+
+  private state = signal<AuthState>({ usuario: null, token: null });
+
+  readonly usuarioAtual = computed(() => this.state().usuario);
+  readonly token = computed(() => this.state().token);
+  readonly autenticado = computed(() => !!this.state().usuario && !!this.state().token);
+
+  constructor() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as AuthState;
+        if (parsed.usuario && parsed.token) {
+          this.state.set(parsed);
+        }
+      } catch (error) {
+        console.warn('Não foi possível restaurar a sessão salva.', error);
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+  }
+
+  async login(email: string, password: string): Promise<void> {
+    const response = await firstValueFrom(
+      this.http.post<LoginResponse>(`${this.apiUrl}/auth/login`, {
+        email: email.trim(),
+        password
+      })
+    );
+
+    const novoEstado: AuthState = {
+      usuario: response.usuario,
+      token: response.token
+    };
+
+    this.state.set(novoEstado);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(novoEstado));
+  }
+
+  logout(): void {
+    this.state.set({ usuario: null, token: null });
+    localStorage.removeItem(STORAGE_KEY);
+    void this.router.navigate(['/login']);
+  }
+}

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -39,6 +39,16 @@ export class DataService {
     }
   }
 
+  async excluirCliente(id: number) {
+    try {
+      await firstValueFrom(this.http.delete(`${this.apiUrl}/clientes/${id}`));
+      await Promise.all([this.carregarClientes(), this.carregarVeiculos(), this.carregarOrdensServico()]);
+    } catch (error) {
+      console.error('Erro ao excluir cliente', error);
+      throw error;
+    }
+  }
+
   async criarCliente(dados: Omit<Cliente, 'id'>) {
     const novo = await firstValueFrom(this.http.post<Cliente>(`${this.apiUrl}/clientes`, dados));
     this.clientes.update(lista => [novo, ...lista.filter(cliente => cliente.id !== novo.id)]);
@@ -61,6 +71,16 @@ export class DataService {
     }
   }
 
+  async excluirVeiculo(id: number) {
+    try {
+      await firstValueFrom(this.http.delete(`${this.apiUrl}/veiculos/${id}`));
+      await Promise.all([this.carregarVeiculos(), this.carregarOrdensServico()]);
+    } catch (error) {
+      console.error('Erro ao excluir veículo', error);
+      throw error;
+    }
+  }
+
   async criarVeiculo(dados: Omit<Veiculo, 'id' | 'clienteNome'>) {
     const novo = await firstValueFrom(this.http.post<Veiculo>(`${this.apiUrl}/veiculos`, dados));
     this.veiculos.update(lista => [novo, ...lista.filter(veiculo => veiculo.id !== novo.id)]);
@@ -79,6 +99,16 @@ export class DataService {
       this.pecas.set(pecas);
     } catch (error) {
       console.error('Erro ao carregar peças', error);
+    }
+  }
+
+  async excluirPeca(id: number) {
+    try {
+      await firstValueFrom(this.http.delete(`${this.apiUrl}/pecas/${id}`));
+      await Promise.all([this.carregarPecas(), this.carregarOrdensServico()]);
+    } catch (error) {
+      console.error('Erro ao excluir peça', error);
+      throw error;
     }
   }
 
@@ -109,6 +139,16 @@ export class DataService {
       this.ordensServico.set(ordens);
     } catch (error) {
       console.error('Erro ao carregar ordens de serviço', error);
+    }
+  }
+
+  async excluirOrdemServico(id: number) {
+    try {
+      await firstValueFrom(this.http.delete(`${this.apiUrl}/ordens-servico/${id}`));
+      await this.carregarOrdensServico();
+    } catch (error) {
+      console.error('Erro ao excluir ordem de serviço', error);
+      throw error;
     }
   }
 

--- a/src/app/pages/estoque.component.ts
+++ b/src/app/pages/estoque.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DataService } from '../core/services/data.service';
@@ -36,7 +36,21 @@ import { Peca } from '../core/models/models';
         </div>
 
         @if (modoVisualizacao() === 'lista') {
-          <div class="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+          <div class="space-y-4">
+            <div class="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex-1">
+                <label class="block text-xs font-semibold uppercase tracking-[0.35em] text-slate-300/80">Pesquisar</label>
+                <input
+                  type="search"
+                  class="mt-2 w-full rounded-xl border border-white/10 bg-slate-900/60 px-4 py-2 text-sm text-slate-100 placeholder:text-slate-400 shadow-inner shadow-slate-950/40 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400/40"
+                  placeholder="Buscar por código ou nome"
+                  [ngModel]="termoBusca()"
+                  (ngModelChange)="termoBusca.set($event)"
+                />
+              </div>
+            </div>
+
+            <div class="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
             <div class="overflow-x-auto">
               <table class="min-w-full divide-y divide-white/10 text-left text-sm text-slate-100">
                 <thead class="bg-white/5 text-xs uppercase tracking-wider text-slate-300">
@@ -49,7 +63,8 @@ import { Peca } from '../core/models/models';
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-white/5 text-sm">
-                  @for (peca of pecas(); track peca.id) {
+                  @if (pecasFiltradas().length) {
+                    @for (peca of pecasFiltradas(); track peca.id) {
                     <tr class="transition hover:bg-white/5">
                       <td class="px-6 py-4 font-medium text-white">{{ peca.codigo }}</td>
                       <td class="px-6 py-4 text-slate-200">{{ peca.nome }}</td>
@@ -66,10 +81,16 @@ import { Peca } from '../core/models/models';
                         </div>
                       </td>
                     </tr>
+                    }
+                  } @else {
+                    <tr>
+                      <td colspan="5" class="px-6 py-6 text-center text-sm text-slate-300">Nenhuma peça encontrada para o filtro aplicado.</td>
+                    </tr>
                   }
                 </tbody>
               </table>
             </div>
+          </div>
           </div>
         }
 
@@ -121,6 +142,16 @@ import { Peca } from '../core/models/models';
             </label>
 
             <div class="md:col-span-2 flex flex-wrap justify-end gap-3">
+              @if (editandoId()) {
+                <button
+                  type="button"
+                  class="rounded-full border border-rose-500/50 bg-rose-500/10 px-5 py-2 text-sm font-medium text-rose-200 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  [disabled]="excluindo()"
+                  (click)="excluirPeca()"
+                >
+                  {{ excluindo() ? 'Excluindo...' : 'Excluir peça' }}
+                </button>
+              }
               <button
                 type="button"
                 class="rounded-full border border-white/15 bg-white/5 px-5 py-2 text-sm font-medium text-slate-200 transition hover:bg-white/10"
@@ -148,6 +179,8 @@ export class EstoqueComponent {
 
   modoVisualizacao = signal<'lista' | 'formulario'>('lista');
   editandoId = signal<number | null>(null);
+  termoBusca = signal('');
+  excluindo = signal(false);
 
   formulario = {
     codigo: '',
@@ -155,6 +188,20 @@ export class EstoqueComponent {
     estoque: 0,
     preco: 0,
   };
+
+  pecasFiltradas = computed(() => {
+    const termo = this.termoBusca().trim().toLowerCase();
+    if (!termo) {
+      return this.pecas();
+    }
+
+    return this.pecas().filter(peca => {
+      const comparaveis = [peca.codigo, peca.nome]
+        .filter(Boolean)
+        .map(valor => valor!.toLowerCase());
+      return comparaveis.some(valor => valor.includes(termo));
+    });
+  });
 
   abrirFormularioNovo() {
     this.editandoId.set(null);
@@ -202,8 +249,30 @@ export class EstoqueComponent {
     }
   }
 
+  async excluirPeca() {
+    if (!this.editandoId()) {
+      return;
+    }
+
+    const confirmar = window.confirm('Deseja realmente excluir esta peça do estoque?');
+    if (!confirmar) {
+      return;
+    }
+
+    this.excluindo.set(true);
+    try {
+      await this.dataService.excluirPeca(this.editandoId()!);
+      this.voltarParaLista();
+    } catch (error) {
+      console.error('Erro ao excluir peça', error);
+    } finally {
+      this.excluindo.set(false);
+    }
+  }
+
   voltarParaLista() {
     this.modoVisualizacao.set('lista');
     this.editandoId.set(null);
+    this.excluindo.set(false);
   }
 }

--- a/src/app/pages/resumo-os.component.ts
+++ b/src/app/pages/resumo-os.component.ts
@@ -1,8 +1,9 @@
-import { Component, computed, inject, Input, signal } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { map } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { DataService } from '../core/services/data.service';
-import { OrdemServico, Veiculo, Cliente, Servico, Peca } from '../core/models/models';
-import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-resumo-os',
@@ -116,12 +117,11 @@ import { RouterLink } from '@angular/router';
 })
 export class ResumoOsComponent {
   private dataService = inject(DataService);
-  private osId = signal<number>(0);
-
-  @Input()
-  set id(osId: string) {
-    this.osId.set(Number(osId));
-  }
+  private route = inject(ActivatedRoute);
+  private osId = toSignal(
+    this.route.paramMap.pipe(map(params => Number(params.get('id')) || 0)),
+    { initialValue: Number(this.route.snapshot.paramMap.get('id')) || 0 }
+  );
 
   osDetails = computed(() => {
     const os = this.dataService.getOrdemServicoById(this.osId());

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,3 +3,27 @@
 @import 'tailwindcss/components';
 
 @import 'tailwindcss/utilities';
+
+html,
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 1));
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+@media print {
+  body {
+    background: #fff !important;
+    color: #0f172a !important;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+
+  #printableArea {
+    box-shadow: none !important;
+    border: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add admin credential storage plus authentication and delete endpoints to the API
- integrate an Angular authentication service/guard with a functional login flow and dynamic header info
- implement list filters, delete actions, and printable order summaries across the OS management screens

## Testing
- `npm run build` *(fails: ng: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f921018e90832193d79f108bea01fb