### PR TITLE
Fix nextId helper when collections are empty

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -122,8 +122,11 @@ function getOrdensServico() {
 }
 
 function nextId(collectionName) {
-  const collection = data[collectionName];
-  const maxId = collection.reduce((max, item) => (item.id > max ? item.id : max), 0);
+  const collection = Array.isArray(data[collectionName]) ? data[collectionName] : [];
+  const maxId = collection.reduce((max, item) => {
+    const itemId = typeof item.id === 'number' ? item.id : Number(item.id);
+    return Number.isFinite(itemId) && itemId > max ? itemId : max;
+  }, 0);
   return maxId + 1;
 }
 


### PR DESCRIPTION
## Summary
- guard the `nextId` helper against missing or empty collections
- ensure non-numeric identifiers do not break identifier generation

## Testing
- node - <<'NODE'
const path = require('path');
const db = require(path.join(process.cwd(), 'PlanuCenter/server/db.js'));

db.data.clientes = [];
console.log('Next cliente id:', db.nextId('clientes'));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68f933095e7c8321afe57b37d2034026