### PR TITLE
Fix Karma test discovery by limiting spec compilation

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -9,6 +9,7 @@
     ]
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- limit the test TypeScript configuration to include only spec files and type declarations so application entrypoints are not executed under Karma

## Testing
- npm test -- --watch=false *(fails: Angular CLI not installed in the execution environment because the registry blocks @angular packages)*

------
https://chatgpt.com/codex/tasks/task_e_68f9383e91248321b0a15ec6949e0018